### PR TITLE
Add support for SQL Server vNext and SSMS 2017 RC1

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -73,3 +73,18 @@ suites:
       max_retries: 4
     verifier:
       command: rspec -c -f d -I spec spec/acceptance/sqlserver2014sp2_2_instances_spec.rb
+  - name: sqlserver2017ctp
+    provisioner:
+      manifest: sqlserver2017ctp.pp
+      custom_facts:
+        sqlserver2017_iso_url: <%= ENV['SQLSERVER2017_ISO_URL'] %>
+    verifier:
+      command: rspec -c -f d -I spec spec/acceptance/sqlserver2017ctp_spec.rb
+  - name: sqlserver2017ctpmultiple
+    provisioner:
+      manifest: sqlserver2017ctp_2_instances.pp
+      custom_facts:
+        sqlserver2017_iso_url: <%= ENV['SQLSERVER2017_ISO_URL'] %>
+      max_retries: 4
+    verifier:
+      command: rspec -c -f d -I spec spec/acceptance/sqlserver2017ctp_2_instances_spec.rb

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -88,3 +88,8 @@ suites:
       max_retries: 4
     verifier:
       command: rspec -c -f d -I spec spec/acceptance/sqlserver2017ctp_2_instances_spec.rb
+  - name: ssms2017
+    provisioner:
+      manifest: ssms2017.pp
+    verifier:
+      command: rspec -c -f d -I spec spec/acceptance/ssms2017_spec.rb

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ ENV['SSL_CERT_FILE'] = "#{rootdir}/cacert.pem" unless ENV['SSL_CERT_FILE']
 namespace :acceptance do
   task :prerequisites do
     raise 'Environment variable SQLSERVER2016_ISO_URL must be set to be able to run our acceptance tests' unless ENV['SQLSERVER2016_ISO_URL']
+    raise 'Environment variable SQLSERVER2017_ISO_URL must be set to be able to run our acceptance tests' unless ENV['SQLSERVER2017_ISO_URL']
   end
 
   desc 'Install puppet modules from Puppetfile'

--- a/manifests/ssms/v2017.pp
+++ b/manifests/ssms/v2017.pp
@@ -1,0 +1,27 @@
+# Install SSMS 2017.
+class sqlserver::ssms::v2017(
+  $source = 'https://go.microsoft.com/fwlink/?LinkID=835608',
+  $filename = 'SSMS-Setup-ENU.exe',
+  $programName = 'Microsoft SQL Server Management Studio - 17.0 RC1',
+  $tempFolder = 'c:/temp'
+  ) {
+
+  include archive
+
+  ensure_resource('file', $tempFolder, { ensure => directory })
+
+  archive { "${tempFolder}/${filename}":
+    source  => $source,
+    require => File[$tempFolder],
+  }
+  ->
+  reboot { 'reboot before installing SSMS (if pending)':
+    when => pending,
+  }
+  ->
+  package { $programName:
+    ensure          => installed,
+    source          => "${tempFolder}/${filename}",
+    install_options => ['/install', '/quiet', '/norestart'],
+  }
+}

--- a/manifests/v2017.pp
+++ b/manifests/v2017.pp
@@ -1,0 +1,30 @@
+# Install SQL Server 2017
+#
+# $source: path to to the SQL Server 2017 Iso file.
+#     (can be a UNC share / URL)
+#
+# $sa_password: The password for the sa account.
+#
+# $install_type: 'RTM' or 'Patch'. Defaults to 'Patch'
+#   'Patch' will upgrade SQL Server to the latest Service Pack.
+#
+# $instance_name: The name of the SQL Server instance.
+#
+class sqlserver::v2017(
+  $source,
+  $sa_password,
+  $install_type   = 'Patch',
+  $instance_name  = 'SQL2017') {
+
+  class { '::sqlserver::v2017::iso':
+    source      => $source,
+  }
+  ->
+  sqlserver::v2017::instance { $instance_name:
+    install_type   => $install_type,
+    install_params => {
+      sapwd => $sa_password,
+    }
+  }
+
+}

--- a/manifests/v2017/instance.pp
+++ b/manifests/v2017/instance.pp
@@ -26,12 +26,13 @@ define sqlserver::v2017::instance(
   }
 
   if $install_type == 'Patch' {
-    require ::sqlserver::v2017::patch
+# Patch is not yet supported for SQL Server 2017, so do just act like base install
+#    require ::sqlserver::v2017::patch
 
-    sqlserver::common::patch_sqlserver_instance { $instance_name:
-      installer_path => $::sqlserver::v2017::patch::installer,
-      patch_version  => $::sqlserver::v2017::patch::version,
-    }
+#    sqlserver::common::patch_sqlserver_instance { $instance_name:
+#      installer_path => $::sqlserver::v2017::patch::installer,
+#      patch_version  => $::sqlserver::v2017::patch::version,
+#    }
   }
 
   if $tcp_port > 0 {

--- a/manifests/v2017/instance.pp
+++ b/manifests/v2017/instance.pp
@@ -38,7 +38,7 @@ define sqlserver::v2017::instance(
   if $tcp_port > 0 {
     sqlserver::common::tcp_port { $instance_name:
       tcp_port          => $tcp_port,
-      sqlserver_version => 13,
+      sqlserver_version => 14,
     }
   }
 

--- a/manifests/v2017/instance.pp
+++ b/manifests/v2017/instance.pp
@@ -25,15 +25,15 @@ define sqlserver::v2017::instance(
     install_params => $install_params,
   }
 
-  if $install_type == 'Patch' {
 # Patch is not yet supported for SQL Server 2017, so do just act like base install
+#  if $install_type == 'Patch' {
 #    require ::sqlserver::v2017::patch
 
 #    sqlserver::common::patch_sqlserver_instance { $instance_name:
 #      installer_path => $::sqlserver::v2017::patch::installer,
 #      patch_version  => $::sqlserver::v2017::patch::version,
 #    }
-  }
+#  }
 
   if $tcp_port > 0 {
     sqlserver::common::tcp_port { $instance_name:

--- a/manifests/v2017/instance.pp
+++ b/manifests/v2017/instance.pp
@@ -1,0 +1,44 @@
+# Install an configure a single SQL Server 2017 Instance.
+#
+# $install_type:
+#   'RTM' (don't patch)
+#   or
+#   'Patch' (install the latest Service Pack/Patch we are aware of.)
+#     The patch installed can be customized by using the ::sqlserver::v2017::patch class.
+#
+define sqlserver::v2017::instance(
+  $instance_name  = $title,
+  $install_type   = 'Patch',
+  $install_params = {},
+  $tcp_port       = 0
+  ) {
+
+  require ::sqlserver::v2017::iso
+
+  Exec {
+    path    => 'C:/Windows/System32',
+    timeout => 1800,
+  }
+
+  sqlserver::common::install_sqlserver_instance { $instance_name:
+    installer_path => $::sqlserver::v2017::iso::installer,
+    install_params => $install_params,
+  }
+
+  if $install_type == 'Patch' {
+    require ::sqlserver::v2017::patch
+
+    sqlserver::common::patch_sqlserver_instance { $instance_name:
+      installer_path => $::sqlserver::v2017::patch::installer,
+      patch_version  => $::sqlserver::v2017::patch::version,
+    }
+  }
+
+  if $tcp_port > 0 {
+    sqlserver::common::tcp_port { $instance_name:
+      tcp_port          => $tcp_port,
+      sqlserver_version => 13,
+    }
+  }
+
+}

--- a/manifests/v2017/iso.pp
+++ b/manifests/v2017/iso.pp
@@ -1,0 +1,9 @@
+# Download and extract a SQL Server 2017 iso.
+class sqlserver::v2017::iso($source) {
+  # $installer points to setup.exe
+  $installer = inline_template('<%= "C:/Windows/Temp/" + File.basename(@source, ".*") + "/setup.exe" %>')
+
+  sqlserver::common::download_installer { $title:
+    source  => $source
+  }
+}

--- a/manifests/v2017/patch.pp
+++ b/manifests/v2017/patch.pp
@@ -1,0 +1,7 @@
+# Download and extract a SQL Server 2017 patch.
+class sqlserver::v2017::patch(
+  $source = '',
+  $version = ''
+  ) {
+  # No Patches available yet
+}

--- a/spec/acceptance/sqlserver2017ctp_2_instances_spec.rb
+++ b/spec/acceptance/sqlserver2017ctp_2_instances_spec.rb
@@ -1,0 +1,38 @@
+# Encoding: utf-8
+require_relative 'spec_windowshelper'
+
+describe package('Microsoft SQL Server vNext CTP1.2 (64-bit)') do
+  it { should be_installed }
+end
+
+['SQL2017_1', 'SQL2017_2'].each do |instance_name|
+
+  describe service("MSSQL$#{instance_name}") do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+    it { should have_start_mode('Automatic') }
+  end
+
+  describe windows_registry_key("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\MSSQL14.#{instance_name}\\Setup") do
+    it { should exist }
+    it { should have_property_value('PatchLevel', :type_string, '14.0.200.24') }
+  end
+end
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL14.SQL2017_1\Setup') do
+  it { should have_property_value('Collation', :type_string, 'Latin1_General_CI_AS') }
+end
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL14.SQL2017_1\Mssqlserver\Supersocketnetlib\tcp\ipall') do
+  it { should have_property_value('tcpport', :type_string, '1433') }
+end
+
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL14.SQL2017_2\Setup') do
+  it { should have_property_value('Collation', :type_string, 'Latin1_General_CS_AS_KS_WS') }
+end
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL14.SQL2017_2\Mssqlserver\Supersocketnetlib\tcp\ipall') do
+  it { should have_property_value('tcpport', :type_string, '1434') }
+end

--- a/spec/acceptance/sqlserver2017ctp_spec.rb
+++ b/spec/acceptance/sqlserver2017ctp_spec.rb
@@ -1,0 +1,15 @@
+# Encoding: utf-8
+require_relative 'spec_windowshelper'
+
+describe package('Microsoft SQL Server vNext CTP1.2 (64-bit)') do
+  it { should be_installed }
+end
+
+['SQLBrowser', 'MSSQL$SQL2017', 'SQLAGENT$SQL2017'].each do |service_name|
+  describe service(service_name) do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+    it { should have_start_mode('Automatic') }
+  end
+end

--- a/spec/acceptance/ssms2017_spec.rb
+++ b/spec/acceptance/ssms2017_spec.rb
@@ -1,0 +1,6 @@
+# Encoding: utf-8
+require_relative 'spec_windowshelper'
+
+describe package('Microsoft SQL Server Management Studio - 17.*') do
+  it { should be_installed}
+end

--- a/spec/manifests/sqlserver2017ctp.pp
+++ b/spec/manifests/sqlserver2017ctp.pp
@@ -1,0 +1,41 @@
+Reboot {
+  timeout => 5,
+}
+
+class { '::sqlserver::v2017':
+  source       => $::sqlserver2017_iso_url,
+  sa_password  => 'sdf347RT!',
+  install_type => 'RTM',
+}
+
+# Test setting options
+
+sqlserver::options::clr_enabled { 'SQL2017: clr enabled':
+  server  => 'localhost\SQL2017',
+  require => Class['::sqlserver::v2017'],
+  value   => 1,
+}
+sqlserver::options::max_memory { 'SQL2017: Max Memory':
+  server  => 'localhost\SQL2017',
+  require => Class['::sqlserver::v2017'],
+  value   => 512,
+}
+sqlserver::options::xp_cmdshell { 'SQL2017: xp_cmdshell':
+  server  => 'localhost\SQL2017',
+  require => Class['::sqlserver::v2017'],
+  value   => 1,
+}
+
+# Test logins/roles
+sqlserver::users::login_windows { 'SQL2017: Everyone login':
+  server     => 'localhost\SQL2017',
+  login_name => '\Everyone',
+  require    => Class['::sqlserver::v2017'],
+}
+->
+sqlserver::users::login_role { 'SQL2017: Everyone is sysadmin':
+  server     => 'localhost\SQL2017',
+  login_name => '\Everyone',
+  role_name  => 'sysadmin',
+  require    => Class['::sqlserver::v2017'],
+}

--- a/spec/manifests/sqlserver2017ctp_2_instances.pp
+++ b/spec/manifests/sqlserver2017ctp_2_instances.pp
@@ -1,0 +1,24 @@
+Reboot {
+  timeout => 5,
+}
+
+class { '::sqlserver::v2017::iso':
+  source => $::sqlserver2017_iso_url,
+}
+
+sqlserver::v2017::instance { 'SQL2017_1':
+  install_type   => 'Patch',
+  install_params => {
+    sapwd => 'sdf347RT!',
+  },
+  tcp_port       => 1433,
+}
+
+sqlserver::v2017::instance { 'SQL2017_2':
+  install_type   => 'Patch',
+  install_params => {
+    sapwd        => 'sdf347RT!',
+    sqlcollation => 'Latin1_General_CS_AS_KS_WS',
+  },
+  tcp_port       => 1434,
+}

--- a/spec/manifests/ssms2017.pp
+++ b/spec/manifests/ssms2017.pp
@@ -1,0 +1,5 @@
+Reboot {
+  timeout => 5,
+}
+
+include ::sqlserver::ssms::v2017


### PR DESCRIPTION
This adds the puppet definitions for SQL Server vNext CTP and SSMS 2017 RC1. We would like to be able to use these now, and then moving them to the Released versions should be straightforward.