### PR TITLE
Allow deployment of multiple updates for a SQL Server instance

### DIFF
--- a/manifests/common/patch_sqlserver_instance.pp
+++ b/manifests/common/patch_sqlserver_instance.pp
@@ -1,13 +1,13 @@
 # Install a patch / Service pack for a SQL Server instance.
 define sqlserver::common::patch_sqlserver_instance(
   $installer_path,
-  $patch_version,
+  $applies_to_version,
   $instance_name = $title
   ) {
 
   # 0 + is needed so that $major_version is an int.
   # https://docs.puppet.com/puppet/latest/lang_data_number.html#converting-strings-to-numbers
-  $major_version = 0 + $patch_version.match(/(\d+)\./)[1]
+  $major_version = 0 + $applies_to_version.match(/(\d+)\./)[1]
 
   $registry_instance_path = "SOFTWARE\\Microsoft\\Microsoft SQL Server\\MSSQL${major_version}.${instance_name}"
   $get_patchlevel_from_registry = "\"HKLM\\${registry_instance_path}\\Setup\" /v PatchLevel"
@@ -25,7 +25,7 @@ define sqlserver::common::patch_sqlserver_instance(
 ${additional_parameters} \
 /ACTION=Patch \
 /INSTANCENAME=${instance_name}",
-    unless  => "cmd.exe /C reg query ${get_patchlevel_from_registry} | findstr ${patch_version}",
+    onlyif  => "cmd.exe /C reg query ${get_patchlevel_from_registry} | findstr ${applies_to_version}",
     require => [
       Exec["Install SQL Server instance: ${instance_name}"],
       Reboot["reboot before installing ${instance_name} Patch (if pending)"]

--- a/manifests/common/patch_sqlserver_instance.pp
+++ b/manifests/common/patch_sqlserver_instance.pp
@@ -1,4 +1,12 @@
 # Install a patch / Service pack for a SQL Server instance.
+#
+# $installer_path: Full path to a setup.exe file.
+#
+# $applies_to_version: The current expected PatchLevel of the SQL Server instance this patch
+#                      is going to be applied to.
+#                      If the PatchLevel is different, than the patch is not applied.
+#
+# $instance_name: The name of the SQL Server instance to patch
 define sqlserver::common::patch_sqlserver_instance(
   $installer_path,
   $applies_to_version,

--- a/manifests/common/patch_sqlserver_instance.pp
+++ b/manifests/common/patch_sqlserver_instance.pp
@@ -26,7 +26,7 @@ define sqlserver::common::patch_sqlserver_instance(
     $additional_parameters = ''
   }
 
-  exec { "Install SQL Server Patch instance: ${instance_name}":
+  exec { "${installer_path} : ${instance_name}":
     command => "\"${installer_path}\" \
 /QUIET \
 /IACCEPTSQLSERVERLICENSETERMS \

--- a/manifests/v2014/instance.pp
+++ b/manifests/v2014/instance.pp
@@ -26,11 +26,12 @@ define sqlserver::v2014::instance(
   }
 
   if $install_type == 'Patch' {
-    require ::sqlserver::v2014::patch
+    require ::sqlserver::v2014::sp2
 
     sqlserver::common::patch_sqlserver_instance { $instance_name:
-      installer_path => $::sqlserver::v2014::patch::installer,
-      patch_version  => $::sqlserver::v2014::patch::version,
+      installer_path     => $::sqlserver::v2014::sp2::installer,
+      applies_to_version => $::sqlserver::v2014::sp2::applies_to_version,
+    }
     }
   }
 

--- a/manifests/v2014/instance.pp
+++ b/manifests/v2014/instance.pp
@@ -27,11 +27,16 @@ define sqlserver::v2014::instance(
 
   if $install_type == 'Patch' {
     require ::sqlserver::v2014::sp2
+    require ::sqlserver::v2014::kb3194714
 
     sqlserver::common::patch_sqlserver_instance { $instance_name:
       installer_path     => $::sqlserver::v2014::sp2::installer,
       applies_to_version => $::sqlserver::v2014::sp2::applies_to_version,
     }
+    ->
+    sqlserver::common::patch_sqlserver_instance { $instance_name:
+      installer_path     => $::sqlserver::v2014::kb3194714::installer,
+      applies_to_version => $::sqlserver::v2014::kb3194714::applies_to_version,
     }
   }
 

--- a/manifests/v2014/instance.pp
+++ b/manifests/v2014/instance.pp
@@ -3,8 +3,7 @@
 # $install_type:
 #   'RTM' (don't patch)
 #   or
-#   'Patch' (install the latest Service Pack/Patch we are aware of.)
-#     The patch installed can be customized by using the ::sqlserver::v2014::patch class.
+#   'Patch' (install the latest Service Pack/Patch/CU we are aware of.)
 #
 define sqlserver::v2014::instance(
   $instance_name  = $title,

--- a/manifests/v2014/instance.pp
+++ b/manifests/v2014/instance.pp
@@ -29,12 +29,14 @@ define sqlserver::v2014::instance(
     require ::sqlserver::v2014::sp2
     require ::sqlserver::v2014::kb3194714
 
-    sqlserver::common::patch_sqlserver_instance { $instance_name:
+    sqlserver::common::patch_sqlserver_instance { "${instance_name}:${::sqlserver::v2014::sp2::installer}":
+      instance_name      => $instance_name,
       installer_path     => $::sqlserver::v2014::sp2::installer,
       applies_to_version => $::sqlserver::v2014::sp2::applies_to_version,
     }
     ->
-    sqlserver::common::patch_sqlserver_instance { $instance_name:
+    sqlserver::common::patch_sqlserver_instance { "${instance_name}:${::sqlserver::v2014::kb3194714::installer}":
+      instance_name      => $instance_name,
       installer_path     => $::sqlserver::v2014::kb3194714::installer,
       applies_to_version => $::sqlserver::v2014::kb3194714::applies_to_version,
     }

--- a/manifests/v2014/kb3194714.pp
+++ b/manifests/v2014/kb3194714.pp
@@ -1,4 +1,4 @@
-# Install "Security Update for SQL Server 2014 Service Pack 2 GDR (KB3194714)"
+# Install "Security Update for SQL Server 2014 Service Pack 2 GDR (KB3194714)" (12.2.5203.0)
 # (https://www.microsoft.com/en-us/download/details.aspx?id=54190)
 class sqlserver::v2014::kb3194714(
   $source = 'https://download.microsoft.com/download/A/4/4/A44A125B-5900-4877-891B-4FE497600419/SQL2014SP2GDR/x64/SQLServer2014-KB3194714-x64.exe',

--- a/manifests/v2014/kb3194714.pp
+++ b/manifests/v2014/kb3194714.pp
@@ -1,0 +1,13 @@
+# Install "Security Update for SQL Server 2014 Service Pack 2 GDR (KB3194714)"
+# (https://www.microsoft.com/en-us/download/details.aspx?id=54190)
+class sqlserver::v2014::kb3194714(
+  $source = 'https://download.microsoft.com/download/A/4/4/A44A125B-5900-4877-891B-4FE497600419/SQL2014SP2GDR/x64/SQLServer2014-KB3194714-x64.exe',
+  $applies_to_version = '12.2.5000.0'
+  ) {
+  # $installer points to setup.exe
+  $installer = inline_template('<%= "C:/Windows/Temp/" + File.basename(@source, ".*") + "/setup.exe" %>')
+
+  sqlserver::common::download_installer { $title:
+    source  => $source
+  }
+}

--- a/manifests/v2014/sp2.pp
+++ b/manifests/v2014/sp2.pp
@@ -1,4 +1,4 @@
-# Download and extract SQL Server 2014 Sp2.
+# Download and extract SQL Server 2014 Sp2. (12.2.5000.0)
 # SQL Server 2014 build versions: https://support.microsoft.com/en-gb/kb/2936603
 class sqlserver::v2014::sp2(
   $source = 'https://download.microsoft.com/download/6/D/9/6D90C751-6FA3-4A78-A78E-D11E1C254700/SQLServer2014SP2-KB3171021-x64-ENU.exe',

--- a/manifests/v2014/sp2.pp
+++ b/manifests/v2014/sp2.pp
@@ -1,8 +1,8 @@
-# Download and extract a SQL Server 2014 patch.
+# Download and extract SQL Server 2014 Sp2.
 # SQL Server 2014 build versions: https://support.microsoft.com/en-gb/kb/2936603
-class sqlserver::v2014::patch(
+class sqlserver::v2014::sp2(
   $source = 'https://download.microsoft.com/download/6/D/9/6D90C751-6FA3-4A78-A78E-D11E1C254700/SQLServer2014SP2-KB3171021-x64-ENU.exe',
-  $version = '12.2.5000.0'
+  $applies_to_version = '12.0.2000.8'
   ) {
   # $installer points to setup.exe
   $installer = inline_template('<%= "C:/Windows/Temp/" + File.basename(@source, ".*") + "/setup.exe" %>')

--- a/manifests/v2016/instance.pp
+++ b/manifests/v2016/instance.pp
@@ -3,8 +3,7 @@
 # $install_type:
 #   'RTM' (don't patch)
 #   or
-#   'Patch' (install the latest Service Pack/Patch we are aware of.)
-#     The patch installed can be customized by using the ::sqlserver::v2016::patch class.
+#   'Patch' (install the latest Service Pack/Patch/CU we are aware of.)
 #
 define sqlserver::v2016::instance(
   $instance_name  = $title,
@@ -26,11 +25,11 @@ define sqlserver::v2016::instance(
   }
 
   if $install_type == 'Patch' {
-    require ::sqlserver::v2016::patch
+    require ::sqlserver::v2016::sp1
 
     sqlserver::common::patch_sqlserver_instance { $instance_name:
-      installer_path => $::sqlserver::v2016::patch::installer,
-      patch_version  => $::sqlserver::v2016::patch::version,
+      installer_path     => $::sqlserver::v2016::sp1::installer,
+      applies_to_version => $::sqlserver::v2016::sp1::applies_to_version,
     }
   }
 

--- a/manifests/v2016/sp1.pp
+++ b/manifests/v2016/sp1.pp
@@ -1,7 +1,8 @@
-# Download and extract a SQL Server 2016 patch.
-class sqlserver::v2016::patch(
+# Download and extract SQL Server 2016 Sp1. (13.1.4001.0)
+# SQL Server 2016 build versions: https://support.microsoft.com/en-us/help/3177312/sql-server-2016-build-versions
+class sqlserver::v2016::sp1(
   $source = 'https://download.microsoft.com/download/3/0/D/30D3ECDD-AC0B-45B5-B8B9-C90E228BD3E5/ENU/SQLServer2016SP1-KB3182545-x64-ENU.exe',
-  $version = '13.1.4001.0'
+  $applies_to_version = '13.0.1601.5'
   ) {
   # $installer points to setup.exe
   $installer = inline_template('<%= "C:/Windows/Temp/" + File.basename(@source, ".*") + "/setup.exe" %>')

--- a/manifests/v2017/instance.pp
+++ b/manifests/v2017/instance.pp
@@ -30,8 +30,8 @@ define sqlserver::v2017::instance(
 #    require ::sqlserver::v2017::patch
 
 #    sqlserver::common::patch_sqlserver_instance { $instance_name:
-#      installer_path => $::sqlserver::v2017::patch::installer,
-#      patch_version  => $::sqlserver::v2017::patch::version,
+#      installer_path     => $::sqlserver::v2017::patch::installer,
+#      applies_to_version => $::sqlserver::v2017::patch::applies_to_version,
 #    }
 #  }
 

--- a/spec/acceptance/sqlserver2014sp2_2_instances_spec.rb
+++ b/spec/acceptance/sqlserver2014sp2_2_instances_spec.rb
@@ -16,7 +16,7 @@ end
 
   describe windows_registry_key("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\MSSQL12.#{instance_name}\\Setup") do
     it { should exist }
-    it { should have_property_value('PatchLevel', :type_string, '12.2.5000.0') }
+    it { should have_property_value('PatchLevel', :type_string, '12.2.5203.0') }
   end
 end
 


### PR DESCRIPTION
This required changing `sqlserver::common::patch_sqlserver_instance` to install a patch when a given `patchlevel` is detected (as opposed to trying to install the patch if the current patchlevel is unexpected)

This change should allow us to deploy more than a single patch/SP to a SQL Server instance.

----
Example for SQL 2014:
 - Install RTM (Set `PatchLevel` to `12.0.2000.8`)
 - Install SP2 (only if `PatchLevel` is `12.0.2000.8`. `PatchLevel` is then set to `12.2.5000.0`)
 - Install KB3194714 (only if `PatchLevel` is `12.2.5000.0`)