### PR TITLE
SQL Server 2012 refactor

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,6 +43,14 @@ suites:
       manifest: localdbs.pp
     verifier:
       command: rspec -c -f d -I spec spec/acceptance/localdbs_spec.rb
+  - name: sqlserver2012sp3
+    provisioner:
+      manifest: sqlserver2012sp3_2_instances.pp
+      custom_facts:
+        sqlserver2014_iso_url: <%= ENV['SQLSERVER2012_ISO_URL'] %>
+      max_retries: 4
+    verifier:
+      command: rspec -c -f d -I spec spec/acceptance/sqlserver2012sp3_2_instances_spec.rb
   - name: sqlserver2016rtm
     provisioner:
       manifest: sqlserver2016rtm.pp

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -47,7 +47,7 @@ suites:
     provisioner:
       manifest: sqlserver2012sp3_2_instances.pp
       custom_facts:
-        sqlserver2014_iso_url: <%= ENV['SQLSERVER2012_ISO_URL'] %>
+        sqlserver2012_iso_url: <%= ENV['SQLSERVER2012_ISO_URL'] %>
       max_retries: 4
     verifier:
       command: rspec -c -f d -I spec spec/acceptance/sqlserver2012sp3_2_instances_spec.rb

--- a/manifests/v2012/instance.pp
+++ b/manifests/v2012/instance.pp
@@ -1,0 +1,44 @@
+# Install an configure a single SQL Server 2012 Instance.
+#
+# $install_type:
+#   'RTM' (don't patch)
+#   or
+#   'Patch' (install the latest Service Pack/Patch/CU we are aware of.)
+#
+define sqlserver::v2012::instance(
+  $instance_name  = $title,
+  $install_type   = 'Patch',
+  $install_params = {},
+  $tcp_port       = 0
+  ) {
+
+  require ::sqlserver::v2012::iso
+
+  Exec {
+    path    => 'C:/Windows/System32',
+    timeout => 1800,
+  }
+
+  sqlserver::common::install_sqlserver_instance { $instance_name:
+    installer_path => $::sqlserver::v2012::iso::installer,
+    install_params => $install_params,
+  }
+
+  if $install_type == 'Patch' {
+    require ::sqlserver::v2012::sp3
+
+    sqlserver::common::patch_sqlserver_instance { $instance_name:
+      instance_name      => $instance_name,
+      installer_path     => $::sqlserver::v2012::sp3::installer,
+      applies_to_version => $::sqlserver::v2012::sp3::applies_to_version,
+    }
+  }
+
+  if $tcp_port > 0 {
+    sqlserver::common::tcp_port { $instance_name:
+      tcp_port          => $tcp_port,
+      sqlserver_version => 11,
+    }
+  }
+
+}

--- a/manifests/v2012/iso.pp
+++ b/manifests/v2012/iso.pp
@@ -1,0 +1,9 @@
+# Download and extract a SQL Server 2012 iso.
+class sqlserver::v2012::iso($source) {
+  # $installer points to setup.exe
+  $installer = inline_template('<%= "C:/Windows/Temp/" + File.basename(@source, ".*") + "/setup.exe" %>')
+
+  sqlserver::common::download_installer { $title:
+    source  => $source
+  }
+}

--- a/manifests/v2012/sp3.pp
+++ b/manifests/v2012/sp3.pp
@@ -1,4 +1,4 @@
-# Download and extract SQL Server 2012 Sp3. (11.00.6020)
+# Download and extract SQL Server 2012 Sp3. (11.3.6020.0)
 # SQL Server 2012 build versions: https://support.microsoft.com/en-us/help/3133750/sql-server-2012-sp3-build-versions
 class sqlserver::v2012::sp3(
   $source = 'https://download.microsoft.com/download/B/1/7/B17F8608-FA44-462D-A43B-00F94591540A/ENU/x64/SQLServer2012SP3-KB3072779-x64-ENU.exe',

--- a/manifests/v2012/sp3.pp
+++ b/manifests/v2012/sp3.pp
@@ -1,0 +1,13 @@
+# Download and extract SQL Server 2012 Sp3. (11.00.6020)
+# SQL Server 2012 build versions: https://support.microsoft.com/en-us/help/3133750/sql-server-2012-sp3-build-versions
+class sqlserver::v2012::sp3(
+  $source = 'https://download.microsoft.com/download/B/1/7/B17F8608-FA44-462D-A43B-00F94591540A/ENU/x64/SQLServer2012SP3-KB3072779-x64-ENU.exe',
+  $applies_to_version = '11.00.3000'
+  ) {
+  # $installer points to setup.exe
+  $installer = inline_template('<%= "C:/Windows/Temp/" + File.basename(@source, ".*") + "/setup.exe" %>')
+
+  sqlserver::common::download_installer { $title:
+    source  => $source
+  }
+}

--- a/spec/acceptance/sqlserver2012sp3_2_instances_spec.rb
+++ b/spec/acceptance/sqlserver2012sp3_2_instances_spec.rb
@@ -16,7 +16,7 @@ end
 
   describe windows_registry_key("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\MSSQL11.#{instance_name}\\Setup") do
     it { should exist }
-    it { should have_property_value('PatchLevel', :type_string, '11.00.6020') }
+    it { should have_property_value('PatchLevel', :type_string, '11.3.6020.0') }
   end
 end
 
@@ -27,7 +27,6 @@ end
 describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL11.SQL2012_1\Mssqlserver\Supersocketnetlib\tcp\ipall') do
   it { should have_property_value('tcpport', :type_string, '1433') }
 end
-
 
 describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL11.SQL2012_2\Setup') do
   it { should have_property_value('Collation', :type_string, 'Latin1_General_CS_AS_KS_WS') }

--- a/spec/acceptance/sqlserver2012sp3_2_instances_spec.rb
+++ b/spec/acceptance/sqlserver2012sp3_2_instances_spec.rb
@@ -1,0 +1,38 @@
+# Encoding: utf-8
+require_relative 'spec_windowshelper'
+
+describe package('Microsoft SQL Server 2012 (64-bit)') do
+  it { should be_installed }
+end
+
+['SQL2012_1', 'SQL2012_2'].each do |instance_name|
+
+  describe service("MSSQL$#{instance_name}") do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+    it { should have_start_mode('Automatic') }
+  end
+
+  describe windows_registry_key("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\MSSQL11.#{instance_name}\\Setup") do
+    it { should exist }
+    it { should have_property_value('PatchLevel', :type_string, '11.00.6020') }
+  end
+end
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL11.SQL2012_1\Setup') do
+  it { should have_property_value('Collation', :type_string, 'Latin1_General_CI_AS') }
+end
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL11.SQL2012_1\Mssqlserver\Supersocketnetlib\tcp\ipall') do
+  it { should have_property_value('tcpport', :type_string, '1433') }
+end
+
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL11.SQL2012_2\Setup') do
+  it { should have_property_value('Collation', :type_string, 'Latin1_General_CS_AS_KS_WS') }
+end
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL11.SQL2012_2\Mssqlserver\Supersocketnetlib\tcp\ipall') do
+  it { should have_property_value('tcpport', :type_string, '1434') }
+end

--- a/spec/manifests/sqlserver2012sp3_2_instances.pp
+++ b/spec/manifests/sqlserver2012sp3_2_instances.pp
@@ -1,0 +1,24 @@
+Reboot {
+  timeout => 5,
+}
+
+class { '::sqlserver::v2012::iso':
+  source => $::sqlserver2012_iso_url,
+}
+
+sqlserver::v2012::instance { 'SQL2012_1':
+  install_type   => 'Patch',
+  install_params => {
+    sapwd => 'sdf347RT!',
+  },
+  tcp_port       => 1433,
+}
+
+sqlserver::v2012::instance { 'SQL2012_2':
+  install_type   => 'Patch',
+  install_params => {
+    sapwd        => 'sdf347RT!',
+    sqlcollation => 'Latin1_General_CS_AS_KS_WS',
+  },
+  tcp_port       => 1434,
+}


### PR DESCRIPTION
Setup SQL Server 2012 instances the same way as we do for 2014, 2016 and 2017