### PR TITLE
sqlserver::sqlcmd::sqlscript resource

### DIFF
--- a/manifests/sqlcmd/install.pp
+++ b/manifests/sqlcmd/install.pp
@@ -1,10 +1,8 @@
 # Install sqlcmd.exe
-class sqlserver::sqlcmd::install($temp_folder = 'C:/temp') {
+class sqlserver::sqlcmd::install($temp_folder = 'C:/Windows/Temp') {
 
   require chocolatey
   include archive
-
-  ensure_resource('file', $temp_folder, { ensure => directory })
 
   if $::architecture == 'x86' {
     $odbcdriver_source = 'https://download.microsoft.com/download/5/7/2/57249A3A-19D6-4901-ACCE-80924ABEB267/ENU/x86/msodbcsql.msi'
@@ -16,7 +14,6 @@ class sqlserver::sqlcmd::install($temp_folder = 'C:/temp') {
 
   archive { "${temp_folder}/msodbcsql.msi":
     source  => $odbcdriver_source,
-    require => File[$temp_folder],
   }
   ->
   package { 'Microsoft ODBC Driver 11 for SQL Server':

--- a/manifests/sqlcmd/install.pp
+++ b/manifests/sqlcmd/install.pp
@@ -1,10 +1,10 @@
 # Install sqlcmd.exe
-class sqlserver::sqlcmd::install($tempFolder = 'C:/temp') {
+class sqlserver::sqlcmd::install($temp_folder = 'C:/temp') {
 
   require chocolatey
   include archive
 
-  ensure_resource('file', $tempFolder, { ensure => directory })
+  ensure_resource('file', $temp_folder, { ensure => directory })
 
   if $::architecture == 'x86' {
     $odbcdriver_source = 'https://download.microsoft.com/download/5/7/2/57249A3A-19D6-4901-ACCE-80924ABEB267/ENU/x86/msodbcsql.msi'
@@ -14,24 +14,24 @@ class sqlserver::sqlcmd::install($tempFolder = 'C:/temp') {
     $sqlcmdutils_source = 'https://download.microsoft.com/download/5/5/B/55BEFD44-B899-4B54-ACD7-506E03142B34/1033/x64/MsSqlCmdLnUtils.msi'
   }
 
-  archive { "${tempFolder}/msodbcsql.msi":
+  archive { "${temp_folder}/msodbcsql.msi":
     source  => $odbcdriver_source,
-    require => File[$tempFolder],
+    require => File[$temp_folder],
   }
   ->
   package { 'Microsoft ODBC Driver 11 for SQL Server':
     ensure          => installed,
-    source          => "${tempFolder}/msodbcsql.msi",
+    source          => "${temp_folder}/msodbcsql.msi",
     install_options => ['ADDLOCAL=ALL', 'IACCEPTMSODBCSQLLICENSETERMS=YES'],
   }
   ->
-  archive { "${tempFolder}/MsSqlCmdLnUtils.msi":
+  archive { "${temp_folder}/MsSqlCmdLnUtils.msi":
     source  => $sqlcmdutils_source,
   }
   ->
   package { 'Microsoft Command Line Utilities 11 for SQL Server':
     ensure          => installed,
-    source          => "${tempFolder}/MsSqlCmdLnUtils.msi",
+    source          => "${temp_folder}/MsSqlCmdLnUtils.msi",
     install_options => ['IACCEPTMSSQLCMDLNUTILSLICENSETERMS=YES'],
   }
 

--- a/manifests/sqlcmd/install.pp
+++ b/manifests/sqlcmd/install.pp
@@ -34,4 +34,16 @@ class sqlserver::sqlcmd::install($tempFolder = 'C:/temp') {
     source          => "${tempFolder}/MsSqlCmdLnUtils.msi",
     install_options => ['IACCEPTMSSQLCMDLNUTILSLICENSETERMS=YES'],
   }
+
+  # The folders where to find sqlcmd.exe
+  $paths = [
+    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/130/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/120/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/110/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/120/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/110/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/100/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/90/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/80/Tools/Binn',
+  ]
 }

--- a/manifests/sqlcmd/sqlquery.pp
+++ b/manifests/sqlcmd/sqlquery.pp
@@ -4,20 +4,20 @@ define sqlserver::sqlcmd::sqlquery($server, $query, $unless = undef, $username =
   require sqlserver::sqlcmd::install
 
   if $username {
-    $authArguments = "-U \"${username}\" -P \"${password}\""
+    $auth_arguments = "-U \"${username}\" -P \"${password}\""
   } else {
-    $authArguments = '-E'
+    $auth_arguments = '-E'
   }
 
   if $unless {
-    $unlesssqlcmd = "sqlcmd.exe -b -V 1 -S ${server} ${authArguments} -Q \"${unless}\""
+    $unlesssqlcmd = "sqlcmd.exe -b -V 1 -S ${server} ${auth_arguments} -Q \"${unless}\""
   } else {
     $unlesssqlcmd = undef
   }
 
   exec { "${title} - ${query}":
     path    => $sqlserver::sqlcmd::install::paths,
-    command => "sqlcmd.exe -b -V 1 -S ${server} ${authArguments} -Q \"${query}\"",
+    command => "sqlcmd.exe -b -V 1 -S ${server} ${auth_arguments} -Q \"${query}\"",
     unless  => $unlesssqlcmd,
   }
 

--- a/manifests/sqlcmd/sqlquery.pp
+++ b/manifests/sqlcmd/sqlquery.pp
@@ -3,18 +3,6 @@ define sqlserver::sqlcmd::sqlquery($server, $query, $unless = undef, $username =
 
   require sqlserver::sqlcmd::install
 
-  # The folders where to find sqlcmd.exe
-  $paths = [
-    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/130/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/120/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/110/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/120/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/110/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/100/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/90/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/80/Tools/Binn',
-  ]
-
   if $username {
     $authArguments = "-U \"${username}\" -P \"${password}\""
   } else {
@@ -28,7 +16,7 @@ define sqlserver::sqlcmd::sqlquery($server, $query, $unless = undef, $username =
   }
 
   exec { "${title} - ${query}":
-    path    => $paths,
+    path    => $sqlserver::sqlcmd::install::paths,
     command => "sqlcmd.exe -b -V 1 -S ${server} ${authArguments} -Q \"${query}\"",
     unless  => $unlesssqlcmd,
   }

--- a/manifests/sqlcmd/sqlscript.pp
+++ b/manifests/sqlcmd/sqlscript.pp
@@ -3,18 +3,6 @@ define sqlserver::sqlcmd::sqlscript($server, $path, $unless = undef, $username =
 
   require sqlserver::sqlcmd::install
 
-  # The folders where to find sqlcmd.exe
-  $paths = [
-    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/130/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/120/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/110/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/120/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/110/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/100/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/90/Tools/Binn',
-    'C:/Program Files/Microsoft SQL Server/80/Tools/Binn',
-  ]
-
   if $username {
     $auth_arguments = "-U \"${username}\" -P \"${password}\""
   } else {
@@ -28,7 +16,7 @@ define sqlserver::sqlcmd::sqlscript($server, $path, $unless = undef, $username =
   }
 
   exec { "${title} - ${path}":
-    path    => $paths,
+    path    => $sqlserver::sqlcmd::install::paths,
     command => "sqlcmd.exe -b -V 1 -S ${server} ${auth_arguments} -i \"${path}\"",
     unless  => $unlesssqlcmd,
   }

--- a/manifests/sqlcmd/sqlscript.pp
+++ b/manifests/sqlcmd/sqlscript.pp
@@ -1,0 +1,36 @@
+# Execute a SQL script using sqlcmd.exe
+define sqlserver::sqlcmd::sqlscript($server, $path, $unless = undef, $username = undef, $password = undef) {
+
+  require sqlserver::sqlcmd::install
+
+  # The folders where to find sqlcmd.exe
+  $paths = [
+    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/130/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/120/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/110/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/120/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/110/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/100/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/90/Tools/Binn',
+    'C:/Program Files/Microsoft SQL Server/80/Tools/Binn',
+  ]
+
+  if $username {
+    $auth_arguments = "-U \"${username}\" -P \"${password}\""
+  } else {
+    $auth_arguments = '-E'
+  }
+
+  if $unless {
+    $unlesssqlcmd = "sqlcmd.exe -b -V 1 -S ${server} ${auth_arguments} -Q \"${unless}\""
+  } else {
+    $unlesssqlcmd = undef
+  }
+
+  exec { "${title} - ${path}":
+    path    => $paths,
+    command => "sqlcmd.exe -b -V 1 -S ${server} ${auth_arguments} -i \"${path}\"",
+    unless  => $unlesssqlcmd,
+  }
+
+}

--- a/spec/acceptance/sqlserver2016sp1_2_instances_spec.rb
+++ b/spec/acceptance/sqlserver2016sp1_2_instances_spec.rb
@@ -36,3 +36,7 @@ end
 describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL13.SQL2016_2\Mssqlserver\Supersocketnetlib\tcp\ipall') do
   it { should have_property_value('tcpport', :type_string, '1434') }
 end
+
+describe command('sqlcmd -s localhost\SQL2016_1 -Q "select name from sys.databases"') do
+  its(:stdout) { should include 'test_database' }
+end

--- a/spec/manifests/sqlserver2016sp1_2_instances.pp
+++ b/spec/manifests/sqlserver2016sp1_2_instances.pp
@@ -54,3 +54,21 @@ sqlserver::users::login_role { 'SQL2016_1: Everyone is sysadmin':
   role_name  => 'sysadmin',
   require    => Sqlserver::V2016::Instance['SQL2016_1'],
 }
+
+$create_database_script = @(SCRIPT)
+  use [master]
+  GO
+  CREATE DATABASE [test_database]
+  GO
+SCRIPT
+
+file { 'C:/Windows/Temp/create_db.sql':
+  content => $create_database_script,
+}
+->
+sqlserver::sqlcmd::sqlscript { 'create test_database on SQL2016_1':
+  server  => 'localhost\SQL2016_1',
+  require => Sqlserver::V2016::Instance['SQL2016_1'],
+  path    => 'C:/Windows/Temp/create_db.sql',
+  unless  => "IF NOT EXISTS(SELECT * FROM sys.databases WHERE name = 'test_database') raiserror ('Database does not exist',1,1)",
+}


### PR DESCRIPTION
`sqlserver::sqlcmd::sqlscript` can be used like `sqlserver::sqlcmd::sqlquery` but will execute a local script . (`sqlcmd.exe -i <path-to-script>`)

also puppet linted the files I touched.