### PR TITLE
LocalDB: Make sure MSSQLLocalDB is created

### DIFF
--- a/manifests/localdb/instance.pp
+++ b/manifests/localdb/instance.pp
@@ -1,27 +1,31 @@
 # make sure that a localdb instance instance is created and is valid.
 #
-# localdb_sql_version: the SQL Server version of localdb. (110, 120)
 # localdb_instance_name: the name of the localdb instance to create
-define sqlserver::localdb::instance($localdb_sql_version = '110', $localdb_instance_name = 'v11.0') {
-
-  $sqllocaldb = "& \"C:/Program Files/Microsoft SQL Server/${localdb_sql_version}/Tools/Binn/sqllocaldb.exe\""
+define sqlserver::localdb::instance($localdb_instance_name = 'v11.0') {
 
   Exec {
-    cwd      => "C:/Program Files/Microsoft SQL Server/${localdb_sql_version}/Tools/Binn",
-    provider => 'powershell',
+    # Use the latest sqllocaldb.exe that can be found.
+    path => [
+      'C:/Program Files/Microsoft SQL Server/140/Tools/Binn',
+      'C:/Program Files/Microsoft SQL Server/130/Tools/Binn',
+      'C:/Program Files/Microsoft SQL Server/120/Tools/Binn',
+      'C:/Program Files/Microsoft SQL Server/110/Tools/Binn',
+      'C:/Windows/system32', # Needed to find cmd.exe
+    ]
   }
 
-  # This command will delete $localdb_instance_name if it is not valid.
+  # This command will delete $localdb_instance_name if it is not valid. (just to make sure the following create gets a chance to work)
   exec { "sqlserver::localdb::instance-delete-${localdb_instance_name}-if-invalid":
-    command   => "${sqllocaldb} delete ${localdb_instance_name}",
-    onlyif    => "if((${sqllocaldb} info ${localdb_instance_name}) -like 'Name:*${localdb_instance_name}') { exit 1 }",
+    command   => "sqllocaldb delete ${localdb_instance_name}",
+    # puppet seems to need "cmd /C" for findstr to work properly...
+    unless    => "cmd /C sqllocaldb info ${localdb_instance_name} | findstr /R \"Name:.*${localdb_instance_name}\"",
     logoutput => true,
   }
-  ->
   # This command will create $localdb_instance_name if it does not exist
-  exec { "sqlserver::localdb::instance-create-${localdb_instance_name}-if-missing":
-    command   => "${sqllocaldb} create ${localdb_instance_name}",
-    unless    => "if((${sqllocaldb} info ${localdb_instance_name}) -like '*\"${localdb_instance_name}\" is not created.') { exit 1 }",
+  -> exec { "sqlserver::localdb::instance-create-${localdb_instance_name}-if-missing":
+    command   => "sqllocaldb create ${localdb_instance_name}",
+    # puppet seems to need "cmd /C" for findstr to work properly...
+    unless    => "cmd /C sqllocaldb info ${localdb_instance_name} | findstr /R \"Name:.*${localdb_instance_name}\"",
     logoutput => true,
   }
 

--- a/manifests/localdb/v2012.pp
+++ b/manifests/localdb/v2012.pp
@@ -6,10 +6,8 @@ class sqlserver::localdb::v2012($tempFolder = 'c:/temp') {
     version    => 2012,
     tempFolder => $tempFolder
   }
-  ->
   # make sure that the v11.0 auto instance is created and is valid.
-  sqlserver::localdb::instance { 'Create v11.0':
-    localdb_sql_version   => '110',
+  -> sqlserver::localdb::instance { 'Create v11.0':
     localdb_instance_name => 'v11.0',
   }
 }

--- a/manifests/localdb/v2014.pp
+++ b/manifests/localdb/v2014.pp
@@ -6,5 +6,8 @@ class sqlserver::localdb::v2014($tempFolder = 'c:/temp') {
     version    => 2014,
     tempFolder => $tempFolder
   }
-
+  # make sure that the MSSQLLocalDB auto instance is created and is valid.
+  -> sqlserver::localdb::instance { 'Create MSSQLLocalDB':
+    localdb_instance_name => 'MSSQLLocalDB',
+  }
 }

--- a/spec/acceptance/localdbs_spec.rb
+++ b/spec/acceptance/localdbs_spec.rb
@@ -13,11 +13,11 @@ describe command("sqllocaldb info") do
 end
 
 describe command("sqllocaldb info MSSQLLocalDB") do
-  its(:stdout) { should match /13.1.4001.0/ }
+  its(:stdout) { should match /Name:\s*MSSQLLocalDB/ }
 end
 
 describe command("sqllocaldb info v11.0") do
-  its(:stdout) { should match /11.0.2318.0/ }
+  its(:stdout) { should match /Name:\s*v11\.0/ }
 end
 
 describe package('Active Directory Authentication Library for SQL Server (x86)') do

--- a/spec/acceptance/localdbs_spec.rb
+++ b/spec/acceptance/localdbs_spec.rb
@@ -12,6 +12,14 @@ describe command("sqllocaldb info") do
   its(:stdout) { should match /v11.0/ }
 end
 
+describe command("sqllocaldb info MSSQLLocalDB") do
+  its(:stdout) { should match /13.1.4001.0/ }
+end
+
+describe command("sqllocaldb info v11.0") do
+  its(:stdout) { should match /11.0.2318.0/ }
+end
+
 describe package('Active Directory Authentication Library for SQL Server (x86)') do
   it { should be_installed }
 end


### PR DESCRIPTION
And refactored `sqlserver::localdb::instance` so that it will use more recent versions of `sqllocaldb.exe` (installed by VS 2017) if found.