### PR TITLE
Apply detected pending reboots immediately

### DIFF
--- a/manifests/common/reboot_resources.pp
+++ b/manifests/common/reboot_resources.pp
@@ -2,10 +2,12 @@
 # SQL Server instances
 define sqlserver::common::reboot_resources($instance_name = $title){
   reboot { "reboot before installing ${instance_name} (if pending)":
-    when => pending,
+    when  => pending,
+    apply => 'immediately',
   }
   reboot { "reboot before installing ${instance_name} Patch (if pending)":
-    when => pending,
+    when  => pending,
+    apply => 'immediately',
   }
   reboot { "Reboot after patching ${instance_name}":
     apply   => finished,


### PR DESCRIPTION
Because the SQL Server installers will complain anyway.