### PR TITLE
Update SSMS 18 Preview 4 to SSMS 18.0 GA

### DIFF
--- a/manifests/ssms/v2018.pp
+++ b/manifests/ssms/v2018.pp
@@ -1,8 +1,8 @@
 # Install SSMS 18 Preview 4
 class sqlserver::ssms::v2018(
-  $source = 'https://go.microsoft.com/fwlink/?linkid=2014662',
+  $source = 'https://go.microsoft.com/fwlink/?linkid=2088649',
   $filename = 'SSMS-Setup-ENU.exe',
-  $programName = 'Microsoft SQL Server Management Studio - 18.0 Preview 4',
+  $programName = 'Microsoft SQL Server Management Studio - 18.0',
   $tempFolder = 'c:/temp'
   ) {
 


### PR DESCRIPTION
Updates our base Vagrant VM to use SSMS 18.0 GA ([released on 24/04/2019](https://cloudblogs.microsoft.com/sqlserver/2019/04/24/sql-server-management-studio-ssms-18-0-released-for-general-availability/)) instead of SSMS 18 Preview 4.