### PR TITLE
Update to SSMS 18.3

### DIFF
--- a/manifests/ssms/v2018.pp
+++ b/manifests/ssms/v2018.pp
@@ -1,8 +1,8 @@
-# Install SSMS 18 Preview 4
+# Install SSMS 18.3
 class sqlserver::ssms::v2018(
-  $source = 'https://go.microsoft.com/fwlink/?linkid=2088649',
+  $source = 'https://go.microsoft.com/fwlink/?linkid=2104251',
   $filename = 'SSMS-Setup-ENU.exe',
-  $programName = 'Microsoft SQL Server Management Studio - 18.0',
+  $programName = 'Microsoft SQL Server Management Studio - 18.3',
   $tempFolder = 'c:/temp'
   ) {
 


### PR DESCRIPTION
Updates our base Vagrant VM to use SSMS 18.3 ([released on 23/09/2019](https://cloudblogs.microsoft.com/sqlserver/2019/09/23/sql-server-management-studio-18-3-is-now-generally-available/)).