### PR TITLE
removing query from the exec title

### DIFF
--- a/manifests/sqlcmd/sqlquery.pp
+++ b/manifests/sqlcmd/sqlquery.pp
@@ -15,7 +15,7 @@ define sqlserver::sqlcmd::sqlquery($server, $query, $unless = undef, $username =
     $unlesssqlcmd = undef
   }
 
-  exec { "${title} - ${query}":
+  exec { $title:
     path        => $sqlserver::sqlcmd::install::paths,
     command     => "sqlcmd.exe -b -V 1 -S ${server} ${auth_arguments} -Q \"${query}\"",
     unless      => $unlesssqlcmd,


### PR DESCRIPTION
# Description
This pull request is to remove `${query}` from the SQL command title. This is a potential security risk if you ran SQL queries containing passwords. As title dropped the entire query on the screen that password is being logged in the console as well as in the log. In case of the log file being compromised the attacker can easily get an access to the sensitive data.