### PR TITLE
Update to SSMS 18.4+

### DIFF
--- a/manifests/ssms/v2018.pp
+++ b/manifests/ssms/v2018.pp
@@ -1,8 +1,8 @@
-# Install SSMS 18.3
+# Install latest SSMS (18.4 as of 06/11/2019)
 class sqlserver::ssms::v2018(
-  $source = 'https://go.microsoft.com/fwlink/?linkid=2105412',
+  $source = 'https://aka.ms/ssmsfullsetup',
   $filename = 'SSMS-Setup-ENU.exe',
-  $programName = 'Microsoft SQL Server Management Studio - 18.3',
+  $programName = 'Microsoft SQL Server Management Studio - 18.4+',
   $tempFolder = 'c:/temp'
   ) {
 

--- a/manifests/ssms/v2018.pp
+++ b/manifests/ssms/v2018.pp
@@ -1,8 +1,8 @@
-# Install latest SSMS (18.4 as of 06/11/2019)
+# Install SSMS 18.4
 class sqlserver::ssms::v2018(
-  $source = 'https://aka.ms/ssmsfullsetup',
+  $source = 'https://go.microsoft.com/fwlink/?linkid=2108895',
   $filename = 'SSMS-Setup-ENU.exe',
-  $programName = 'Microsoft SQL Server Management Studio - 18.4+',
+  $programName = 'Microsoft SQL Server Management Studio - 18.4',
   $tempFolder = 'c:/temp'
   ) {
 


### PR DESCRIPTION
Updates our base Vagrant VM to use SSMS `18.4+` ([released on 04/11/2019](https://cloudblogs.microsoft.com/sqlserver/2019/11/05/sql-server-management-studio-18-4-and-sqlpackage-v18-4-generally-available/)).

**NOTE:** Unlike in previous versions that used a forward link with a specific link id, MS seem to have gone the route of a single 'aka' (https://aka.ms/ssmsfullsetup) redirect for the latest version, which means that future releases (e.g. `18.4.1` or `18.5`) might still be using this link.