### PR TITLE
Update SSMS18 VM to use version 18.6

### DIFF
--- a/manifests/ssms/v2018.pp
+++ b/manifests/ssms/v2018.pp
@@ -1,8 +1,8 @@
-# Install SSMS 18.4
+# Install SSMS 18.6
 class sqlserver::ssms::v2018(
-  $source = 'https://go.microsoft.com/fwlink/?linkid=2108895',
+  $source = 'https://download.microsoft.com/download/d/9/7/d9789173-aaa7-4f5b-91b0-a2a01f4ba3a6/SSMS-Setup-ENU.exe',
   $filename = 'SSMS-Setup-ENU.exe',
-  $programName = 'Microsoft SQL Server Management Studio - 18.4',
+  $programName = 'Microsoft SQL Server Management Studio - 18.6',
   $tempFolder = 'C:/Windows/Temp',
   ) {
 


### PR DESCRIPTION
This updates the SSMS 18 VM to use SSMS version 18.6 (from 18.4). This is wanted because there was a breaking change between versions 18.4 and 18.5, and the Prompt team want to test using the version after this change.

I couldn't find a link to the 18.6 installer using a similar format to the previous version (`go.microsoft.com/fwlink/?linkid=...`). The only links I could find provided for MS were `https://aka.ms/ssmsfullsetup` and `https://download.microsoft.com/download/d/9/7/d9789173-aaa7-4f5b-91b0-a2a01f4ba3a6/SSMS-Setup-ENU.exe`. I decided to use the latter since it looked like the former would link to different versions when they come available, and I thought consistency would be best.

I haven't tested this. I'm not sure how to without it being merged into `master`.