### PR TITLE
Polybase

### DIFF
--- a/manifests/v2019/instance.pp
+++ b/manifests/v2019/instance.pp
@@ -9,7 +9,15 @@
 define sqlserver::v2019::instance(
   $instance_name  = $title,
   $install_type   = 'Patch',
-  $install_params = {},
+  $install_params = {
+    features              => 'SQL,Tools,PolyBase',
+    pbscaleout            => 'true',
+    pbportrange           => '16450-16460',
+    pbengsvcaccount       => 'BUILTIN\\Administrators',
+    pbengsvcpassword      => 'YouBetterChangeThis!',
+    pbdmssvcaccount       => "<DomainName>\<UserName>',
+    pbdmssvcpassword      => 'YouBetterChangeThis!',
+  },
   $tcp_port       = 0
   ) {
 

--- a/manifests/v2019/instance.pp
+++ b/manifests/v2019/instance.pp
@@ -15,7 +15,7 @@ define sqlserver::v2019::instance(
     pbportrange           => '16450-16460',
     pbengsvcaccount       => 'BUILTIN\\Administrators',
     pbengsvcpassword      => 'YouBetterChangeThis!',
-    pbdmssvcaccount       => "<DomainName>\<UserName>',
+    pbdmssvcaccount       => 'BUILTIN\\Administrators',
     pbdmssvcpassword      => 'YouBetterChangeThis!',
   },
   $tcp_port       = 0


### PR DESCRIPTION
## What does this PR do?
We've been asked to support Polybase in SQL Compare, for which we'll need instances to test against, so I've attempted to configure that here. Based on instructions at https://docs.microsoft.com/en-us/sql/relational-databases/polybase/polybase-installation?view=sql-server-ver15

## Caveats
 - I have no idea how to puppet
 - I've wedged provisional passwords in there, not sure how this should work
- This PR may not be the way you want to go anyway: I'm not sure if we ought to be moving to vagrant instead of continuing to work on the `is-sql*.testnet` machines.