### PR TITLE
Add SQL Server 2022 CTP

### DIFF
--- a/.kitchen.sqlservers.yml
+++ b/.kitchen.sqlservers.yml
@@ -95,3 +95,12 @@ suites:
         sqlserver2019_iso_url: <%= ENV['SQLSERVER2019_ISO_URL'] %>
     verifier:
       command: rspec -c -f d -I spec spec/acceptance/sqlserver2019rtm_2_instances_spec.rb
+  - name: sqlserver2022multiple
+    excludes:
+      - windows-2012r2
+    provisioner:
+      manifest: sqlserver2022ctp_2_instances.pp
+      custom_facts:
+        sqlserver2022_iso_url: <%= ENV['SQLSERVER2022_ISO_URL'] %>
+    verifier:
+      command: rspec -c -f d -I spec spec/acceptance/sqlserver2022ctp_2_instances_spec.rb

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,7 @@ namespace :acceptance do
       raise 'Environment variable SQLSERVER2016_ISO_URL must be set to be able to run our acceptance tests' unless ENV['SQLSERVER2016_ISO_URL']
       raise 'Environment variable SQLSERVER2017_ISO_URL must be set to be able to run our acceptance tests' unless ENV['SQLSERVER2017_ISO_URL']
       raise 'Environment variable SQLSERVER2019_ISO_URL must be set to be able to run our acceptance tests' unless ENV['SQLSERVER2019_ISO_URL']
+      raise 'Environment variable SQLSERVER2022_ISO_URL must be set to be able to run our acceptance tests' unless ENV['SQLSERVER2022_ISO_URL']
     end
   end
 

--- a/manifests/v2022/instance.pp
+++ b/manifests/v2022/instance.pp
@@ -1,0 +1,44 @@
+# Install an configure a single SQL Server 2022 Instance.
+#
+# $install_type:
+#   'RTM'/'CTP' (don't patch)
+#   or
+#   'Patch' (install the latest Service Pack/Patch we are aware of.)
+#     The patch installed can be customized by using the ::sqlserver::v2022::patch class.
+#
+define sqlserver::v2022::instance(
+  $instance_name  = $title,
+  $install_type   = 'Patch',
+  $install_params = {},
+  $tcp_port       = 0
+  ) {
+
+  require ::sqlserver::v2022::iso
+
+  Exec {
+    path    => 'C:/Windows/System32',
+    timeout => 1800,
+  }
+
+  sqlserver::common::install_sqlserver_instance { $instance_name:
+    installer_path => $::sqlserver::v2022::iso::installer,
+    install_params => $install_params,
+  }
+
+# Patch is not yet supported for SQL Server 2022, so do just act like base install
+#  if $install_type == 'Patch' {
+#    require ::sqlserver::v2022::patch
+
+#    sqlserver::common::patch_sqlserver_instance { $instance_name:
+#      installer_path     => $::sqlserver::v2022::patch::installer,
+#      applies_to_version => $::sqlserver::v2022::patch::applies_to_version,
+#    }
+#  }
+
+  if $tcp_port > 0 {
+    sqlserver::common::tcp_port { $instance_name:
+      tcp_port => $tcp_port,
+    }
+  }
+
+}

--- a/manifests/v2022/iso.pp
+++ b/manifests/v2022/iso.pp
@@ -1,0 +1,10 @@
+# Download and extract a SQL Server 2022 iso.
+class sqlserver::v2022::iso($source) {
+
+  # $installer points to setup.exe
+  $installer = inline_template('<%= "C:/Windows/Temp/" + File.basename(@source, ".*") + "/setup.exe" %>')
+
+  sqlserver::common::download_installer { $title:
+    source  => $source
+  }
+}

--- a/manifests/v2022/patch.pp
+++ b/manifests/v2022/patch.pp
@@ -1,0 +1,7 @@
+# Download and extract a SQL Server 2022 patch.
+class sqlserver::v2022::patch(
+  $source = '',
+  $version = ''
+  ) {
+  # No Patches available yet
+}

--- a/spec/acceptance/sqlserver2022ctp_2_instances_spec.rb
+++ b/spec/acceptance/sqlserver2022ctp_2_instances_spec.rb
@@ -1,0 +1,38 @@
+# Encoding: utf-8
+require_relative 'spec_windowshelper'
+
+describe package('Microsoft SQL Server * (64-bit)') do
+  it { should be_installed }
+end
+
+['SQL2022_1', 'SQL2022_2'].each do |instance_name|
+
+  describe service("MSSQL$#{instance_name}") do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+    it { should have_start_mode('Automatic') }
+  end
+
+  describe windows_registry_key("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\MSSQL16.#{instance_name}\\Setup") do
+    it { should exist }
+    it { should have_property_value('PatchLevel', :type_string, '16.0.600.9') }
+  end
+end
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL16.SQL2022_1\Setup') do
+  it { should have_property_value('Collation', :type_string, 'Latin1_General_CI_AS') }
+end
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL16.SQL2022_1\Mssqlserver\Supersocketnetlib\tcp\ipall') do
+  it { should have_property_value('tcpport', :type_string, '1433') }
+end
+
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL16.SQL2022_2\Setup') do
+  it { should have_property_value('Collation', :type_string, 'Latin1_General_CS_AS_KS_WS') }
+end
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL16.SQL2022_2\Mssqlserver\Supersocketnetlib\tcp\ipall') do
+  it { should have_property_value('tcpport', :type_string, '1434') }
+end

--- a/spec/manifests/sqlserver2022ctp_2_instances.pp
+++ b/spec/manifests/sqlserver2022ctp_2_instances.pp
@@ -1,0 +1,84 @@
+Reboot {
+  timeout => 10,
+}
+
+class { '::sqlserver::v2022::iso':
+  source => $::sqlserver2022_iso_url,
+}
+
+sqlserver::v2022::instance { 'SQL2022_1':
+  install_type   => 'Patch',
+  install_params => {
+    sapwd => 'sdf347RT!',
+  },
+  tcp_port       => 1433,
+}
+
+sqlserver::v2022::instance { 'SQL2022_2':
+  install_type   => 'CTP',
+  install_params => {
+    sapwd        => 'sdf347RT!',
+    sqlcollation => 'Latin1_General_CS_AS_KS_WS',
+  },
+  tcp_port       => 1434,
+}
+
+
+# Test setting options with the first instance
+
+sqlserver::options::clr_enabled { 'SQL2022_1: clr enabled':
+  server  => 'localhost\SQL2022_1',
+  require => Sqlserver::V2022::Instance['SQL2022_1'],
+  value   => 1,
+}
+sqlserver::options::max_memory { 'SQL2022_1: Max Memory':
+  server  => 'localhost\SQL2022_1',
+  require => Sqlserver::V2022::Instance['SQL2022_1'],
+  value   => 512,
+}
+sqlserver::options::xp_cmdshell { 'SQL2022_1: xp_cmdshell':
+  server  => 'localhost\SQL2022_1',
+  require => Sqlserver::V2022::Instance['SQL2022_1'],
+  value   => 1,
+}
+
+sqlserver::database::readonly { 'SQL2022_1: Set model readonly':
+  server        => 'localhost\SQL2022_1',
+  database_name => 'model',
+  require       => Sqlserver::V2022::Instance['SQL2022_1'],
+}
+
+# Test logins/roles
+sqlserver::users::login_windows { 'SQL2022_1: Everyone login':
+  server     => 'localhost\SQL2022_1',
+  login_name => '\Everyone',
+  require    => Sqlserver::V2022::Instance['SQL2022_1'],
+}
+-> sqlserver::users::login_role { 'SQL2022_1: Everyone is sysadmin':
+  server     => 'localhost\SQL2022_1',
+  login_name => '\Everyone',
+  role_name  => 'sysadmin',
+}
+-> sqlserver::users::default_database { 'SQL2022_1: Everyone default database is tempdb':
+  server                => 'localhost\SQL2022_1',
+  login_name            => '\Everyone',
+  default_database_name => 'tempdb',
+}
+
+# SQL Server login
+sqlserver::users::login_sql { 'SQL2022_1: sql_user login':
+  server     => 'localhost\SQL2022_1',
+  login_name => 'sql_user',
+  password   => 'SomePassw0rdForT3stPurposes!',
+  require    => Sqlserver::V2022::Instance['SQL2022_1'],
+}
+-> sqlserver::users::login_role { 'SQL2022_1: sql_user is sysadmin':
+  server     => 'localhost\SQL2022_1',
+  login_name => 'sql_user',
+  role_name  => 'sysadmin',
+}
+-> sqlserver::users::default_database { 'SQL2022_1: sql_user default database is tempdb':
+  server                => 'localhost\SQL2022_1',
+  login_name            => 'sql_user',
+  default_database_name => 'tempdb',
+}


### PR DESCRIPTION
Adding SQL 2022 CTP to the module.
Just following the existing method used for previous versions.
This includes some basic kitchen tests.