### PR TITLE
Add SSMS 19 Preview 2 definition

### DIFF
--- a/.kitchen.ssms.yml
+++ b/.kitchen.ssms.yml
@@ -57,3 +57,8 @@ suites:
       manifest: ssms2018.pp
     verifier:
       command: rspec -c -f d -I spec spec/acceptance/ssms2018_spec.rb
+  - name: ssms19
+    provisioner:
+      manifest: ssms19.pp
+    verifier:
+      command: rspec -c -f d -I spec spec/acceptance/ssms19_spec.rb

--- a/manifests/ssms/v19.pp
+++ b/manifests/ssms/v19.pp
@@ -1,0 +1,22 @@
+# Install SSMS 19 Preview 2
+class sqlserver::ssms::v19(
+  $source = 'https://go.microsoft.com/fwlink/?linkid=2195969&clcid=0x409',
+  $filename = 'SSMS-Setup-ENU.exe',
+  $programName = 'Microsoft SQL Server Management Studio 19',
+  $tempFolder = 'C:/Windows/Temp',
+  ) {
+
+  include archive
+
+  archive { "${tempFolder}/${filename}":
+    source  => $source,
+  }
+  -> reboot { 'reboot before installing SSMS (if pending)':
+    when => pending,
+  }
+  -> package { $programName:
+    ensure          => installed,
+    source          => "${tempFolder}/${filename}",
+    install_options => ['/install', '/quiet', '/norestart'],
+  }
+}

--- a/spec/acceptance/ssms19_spec.rb
+++ b/spec/acceptance/ssms19_spec.rb
@@ -1,0 +1,5 @@
+require_relative 'spec_windowshelper'
+
+describe package('Microsoft SQL Server Management Studio - 19.*') do
+  it { should be_installed}
+end

--- a/spec/manifests/ssms19.pp
+++ b/spec/manifests/ssms19.pp
@@ -1,0 +1,5 @@
+Reboot {
+  timeout => 10,
+}
+
+include ::sqlserver::ssms::v19


### PR DESCRIPTION
Added a definition for SSMS 19 Preview 2, so that the Honeybees Team can use it in our tests. I've mostly copied the SSMS 18 definition, so it should work. 