### PR TITLE
Fix the SSMS 19 definitions

### DIFF
--- a/.kitchen.ssms.yml
+++ b/.kitchen.ssms.yml
@@ -28,10 +28,10 @@ verifier:
   name: shell
 
 platforms:
-  - name: windows-2016
+  - name: windows-2019
     driver_plugin: vagrant
     driver_config:
-      box: red-gate/windows-2016
+      box: red-gate/windows-2019
       provision: true
       vagrantfiles:
         - spec/vagrantfile.rb

--- a/manifests/ssms/v19.pp
+++ b/manifests/ssms/v19.pp
@@ -2,7 +2,7 @@
 class sqlserver::ssms::v19(
   $source = 'https://go.microsoft.com/fwlink/?linkid=2195969&clcid=0x409',
   $filename = 'SSMS-Setup-ENU.exe',
-  $programName = 'Microsoft SQL Server Management Studio 19',
+  $programName = 'Microsoft SQL Server Management Studio - 19.0 Preview 2',
   $tempFolder = 'C:/Windows/Temp',
   ) {
 


### PR DESCRIPTION
The kitchen tests were failing. I've tweaked the definition so they [now pass.](https://buildserver.red-gate.com/buildConfiguration/Puppet_AcceptanceTests_StandloneModules_Sqlserver_KitchenSsmsYml/17174317?showRootCauses=true&expandBuildChangesSection=true)  