### PR TITLE
fix kitchen tests for sql 2022 and 32-bit OS

### DIFF
--- a/.kitchen.sqlservers.yml
+++ b/.kitchen.sqlservers.yml
@@ -173,7 +173,7 @@ suites:
       custom_facts:
         sqlserver2022_iso_url: <%= ENV['SQLSERVER2022_ISO_URL'] %>
     verifier:
-      command: rspec -c -f d -I spec spec/acceptance/sqlserver2022ctp_2_instances_spec.rb
+      command: rspec -c -f d -I spec spec/acceptance/sqlserver2022rtm_2_instances_spec.rb
   - name: sqlserver2019linux
     excludes:
       - windows-2012r2

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,7 @@ source 'https://rubygems.org'
 gem 'puppet-lint'
 
 gem 'test-kitchen', '~> 2'
-# Use our own fork which makes it easier to download the latest version of puppet 6 for windows
-gem 'kitchen-puppet', :git => 'https://github.com/red-gate/kitchen-puppet', :branch => 'master'
+gem 'kitchen-puppet', '~> 3'
 gem 'kitchen-vagrant', '~> 1'
 gem 'kitchen-zip', :git => 'https://github.com/red-gate/kitchen-zip', :branch => 'master'
 

--- a/spec/acceptance/sqlserver2022rtm_2_instances_spec.rb
+++ b/spec/acceptance/sqlserver2022rtm_2_instances_spec.rb
@@ -16,7 +16,7 @@ end
 
   describe windows_registry_key("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\MSSQL16.#{instance_name}\\Setup") do
     it { should exist }
-    it { should have_property_value('PatchLevel', :type_string, '16.0.600.9') }
+    it { should have_property_value('PatchLevel', :type_string, '16.0.1000.6') }
   end
 end
 


### PR DESCRIPTION
Update the kitchen tests for SQL 2022
Switch to original kitchen-puppet provisioner to fix 32-bit puppet issues