### PR TITLE
Handle duplicate declaration

### DIFF
--- a/manifests/common/install_sqlserver_instance.pp
+++ b/manifests/common/install_sqlserver_instance.pp
@@ -77,7 +77,9 @@ define sqlserver::common::install_sqlserver_instance (
 
   if ($certificate_thumbprint) {
     $svc_account = $params['sqlsvcaccount']
-    sslcertificate::key_acl { "${svc_account}_certificate_read":
+
+    # Include instance name here to avoid duplicate declarations where more than one SQL instance exists on the same server
+    sslcertificate::key_acl { "${instance_name}_${svc_account}_certificate_read":
       identity        => $svc_account,
       cert_thumbprint => $certificate_thumbprint,
       require         => Exec["Install SQL Server instance: ${instance_name}"],
@@ -86,7 +88,7 @@ define sqlserver::common::install_sqlserver_instance (
     sqlserver::common::set_tls_cert { "Set_TLS_certificate_for_${instance_name}":
       certificate_thumbprint => $certificate_thumbprint,
       instance_name => $instance_name,
-      require => [Exec["Install SQL Server instance: ${instance_name}"], Sslcertificate::Key_acl["${svc_account}_certificate_read"]],
+      require => [Exec["Install SQL Server instance: ${instance_name}"], Sslcertificate::Key_acl["${instance_name}_${svc_account}_certificate_read"]],
     }
   }
 }

--- a/spec/manifests/sqlserver2008sp4_2_instances.pp
+++ b/spec/manifests/sqlserver2008sp4_2_instances.pp
@@ -76,6 +76,8 @@ sqlserver::v2008::instance { 'SQL2008_2':
     sqlcollation => 'Latin1_General_CS_AS_KS_WS',
   },
   tcp_port       => 1434,
+  certificate_thumbprint => '3401AEE89B13985BFE3BEFFDE853D574E0243E09',
+  require => Sslcertificate::From_pem['test-cert'],
 }
 
 # Test setting options with the first instance


### PR DESCRIPTION
Make the `sslcertificate::key_acl` resource name unique so that we don't be duplicate resources created when more than one instance is installed on a node.