### PR TITLE
fix: SQL2008R2 patch installation

### DIFF
--- a/manifests/common/patch_sqlserver_instance.pp
+++ b/manifests/common/patch_sqlserver_instance.pp
@@ -29,6 +29,7 @@ define sqlserver::common::patch_sqlserver_instance (
   $get_patchlevel_from_registry = "\"HKLM\\${registry_instance_path}\\Setup\" /v PatchLevel"
 
   case $major_version {
+    10: { if($minor == 50) { $additional_parameters = '/IACCEPTSQLSERVERLICENSETERMS' } }
     11, 12: { $additional_parameters = '/IACCEPTSQLSERVERLICENSETERMS' }
     13: { $additional_parameters = '/IACCEPTSQLSERVERLICENSETERMS /IACCEPTROPENLICENSETERMS' }
     default: { $additional_parameters = '' }

--- a/manifests/common/patch_sqlserver_instance.pp
+++ b/manifests/common/patch_sqlserver_instance.pp
@@ -17,8 +17,15 @@ define sqlserver::common::patch_sqlserver_instance (
 ) {
   # https://www.puppet.com/docs/puppet/7/lang_data_number.html#lang_data_number_convert_strings
   $major_version = Integer($applies_to_version.match(/(\d+)\./)[1])
+  $minor = Integer($applies_to_version.match(/(\d+)\.(\d+)\./)[2])
+  if($minor == 50) {
+    $version_path_component = "${major_version}_${minor}"
+  }
+  else {
+    $version_path_component = $major_version
+  }
 
-  $registry_instance_path = "SOFTWARE\\Microsoft\\Microsoft SQL Server\\MSSQL${major_version}.${instance_name}"
+  $registry_instance_path = "SOFTWARE\\Microsoft\\Microsoft SQL Server\\MSSQL${version_path_component}.${instance_name}"
   $get_patchlevel_from_registry = "\"HKLM\\${registry_instance_path}\\Setup\" /v PatchLevel"
 
   case $major_version {

--- a/spec/acceptance/sqlserver2008r2_2_instances_spec.rb
+++ b/spec/acceptance/sqlserver2008r2_2_instances_spec.rb
@@ -15,7 +15,7 @@ end
 
   describe windows_registry_key("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\MSSQL10_50.#{instance_name}\\Setup") do
     it { should exist }
-    it { should have_property_value('PatchLevel', :type_string, '10.50.1600.1') }
+    it { should have_property_value('PatchLevel', :type_string, '10.50.6000.34') }
   end
 end
 

--- a/spec/acceptance/sqlserver2008r2_2_instances_spec.rb
+++ b/spec/acceptance/sqlserver2008r2_2_instances_spec.rb
@@ -15,7 +15,7 @@ end
 
   describe windows_registry_key("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\MSSQL10_50.#{instance_name}\\Setup") do
     it { should exist }
-    it { should have_property_value('PatchLevel', :type_string, '10.50.6000.34') }
+    it { should have_property_value('PatchLevel', :type_string, '10.53.6000.34') }
   end
 end
 

--- a/spec/manifests/sqlserver2008r2_2_instances.pp
+++ b/spec/manifests/sqlserver2008r2_2_instances.pp
@@ -60,7 +60,7 @@ class { 'sqlserver::v2008r2::iso':
 }
 
 sqlserver::v2008r2::instance { 'SQL2008R2_1':
-  install_type   => 'RTM',
+  install_type   => 'SP3',
   install_params => {
     sapwd => 'sdf347RT!',
   },
@@ -70,7 +70,7 @@ sqlserver::v2008r2::instance { 'SQL2008R2_1':
 }
 
 sqlserver::v2008r2::instance { 'SQL2008R2_2':
-  install_type   => 'RTM',
+  install_type   => 'SP3',
   install_params => {
     sapwd        => 'sdf347RT!',
     sqlcollation => 'Latin1_General_CS_AS_KS_WS',


### PR DESCRIPTION
We mistakenly assumed that the registry path only ever included the major version number. However, for SQL2008R2 it also includes the minor version, e.g. the registry path includes `10_50` instead of just `10`.

This slightly dubious workaround should deal with that case and allow the patch installation to work.