### PR TITLE
only reboot if sql[version] not found in instance name in registry

### DIFF
--- a/lib/facter/sqlserver_instances.rb
+++ b/lib/facter/sqlserver_instances.rb
@@ -10,9 +10,16 @@ Facter.add('sqlserver_instances') do
       hive.open('SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL', Win32::Registry::KEY_READ | 0x100) do |reg|
         result = {}
         reg.each_value do |name|
+          patch_level = ""
+          
+          Win32::Registry::HKEY_LOCAL_MACHINE.open("SOFTWARE\\Microsoft\\Microsoft SQL Server\\#{reg[name]}\\Setup") do |patch|
+            patch_level = patch['PatchLevel']
+          end
+          
           result[name] = Hash[
             instance_name: reg[name],
-            registry_path: "SOFTWARE\\Microsoft\\Microsoft SQL Server\\#{reg[name]}"
+            registry_path: "SOFTWARE\\Microsoft\\Microsoft SQL Server\\#{reg[name]}",
+            patch_level: patch_level
           ]
         end
         result

--- a/manifests/common/install_sqlserver_instance.pp
+++ b/manifests/common/install_sqlserver_instance.pp
@@ -75,13 +75,13 @@ define sqlserver::common::install_sqlserver_instance (
       command => "\"${installer_path}\" ${quiet_params} ${parameters} /SkipRules=ServerCoreBlockUnsupportedSxSCheck",
       unless  => "reg.exe query ${get_instancename_from_registry}",
       require => Reboot["reboot before installing ${instance_name} (if pending)"],
-      before  => Anchor['sql reboot ordering'],
+      before  => Anchor["${instance_name} reboot ordering"],
       returns => [0,3010],
     }
   }
 
   # Use an achor to order the SQL install and certificate updates even if only one or other is actually needed during this run.
-  anchor { 'sql reboot ordering': }
+  anchor { "${instance_name} reboot ordering": }
 
   if ($certificate_thumbprint) {
 
@@ -89,7 +89,7 @@ define sqlserver::common::install_sqlserver_instance (
     sslcertificate::key_acl { "${instance_name}_${svc_account}_certificate_read":
       identity        => $svc_account,
       cert_thumbprint => $certificate_thumbprint,
-      require => Anchor['sql reboot ordering'],
+      require => Anchor["${instance_name} reboot ordering"],
     }
 
     sqlserver::common::set_tls_cert { "Set_TLS_certificate_for_${instance_name}":

--- a/manifests/common/install_sqlserver_instance.pp
+++ b/manifests/common/install_sqlserver_instance.pp
@@ -73,7 +73,7 @@ define sqlserver::common::install_sqlserver_instance (
       command => "\"${installer_path}\" ${quiet_params} ${parameters} /SkipRules=ServerCoreBlockUnsupportedSxSCheck",
       unless  => "reg.exe query ${get_instancename_from_registry}",
       require => Reboot["reboot before installing ${instance_name} (if pending)"],
-      before  => Sslcertificate::Key_acl["${instance_name}_${svc_account}_certificate_read"]
+      before  => Sslcertificate::Key_acl["${instance_name}_${svc_account}_certificate_read"],
       returns => [0,3010],
     }
   }

--- a/manifests/common/install_sqlserver_instance.pp
+++ b/manifests/common/install_sqlserver_instance.pp
@@ -64,7 +64,9 @@ define sqlserver::common::install_sqlserver_instance (
   # Override the default parameters with parameters passed in $install_params
   $params = deep_merge($default_parameters, $install_params)
 
-  sqlserver::common::reboot_resources { $instance_name: }
+  if (!$facts['sqlserver_instances'][$instance_name]) {
+    sqlserver::common::reboot_resources { $instance_name: }
+  }
 
   $parameters = convert_to_parameter_string($params)
 

--- a/manifests/common/install_sqlserver_instance.pp
+++ b/manifests/common/install_sqlserver_instance.pp
@@ -73,7 +73,7 @@ define sqlserver::common::install_sqlserver_instance (
       command => "\"${installer_path}\" ${quiet_params} ${parameters} /SkipRules=ServerCoreBlockUnsupportedSxSCheck",
       unless  => "reg.exe query ${get_instancename_from_registry}",
       require => Reboot["reboot before installing ${instance_name} (if pending)"],
-      before  => Sslcertificate::Key_acl["${instance_name}_${svc_account}_certificate_read"],
+      before  => [Sslcertificate::Key_acl["${instance_name}_${svc_account}_certificate_read"]],
       returns => [0,3010],
     }
   }
@@ -90,7 +90,7 @@ define sqlserver::common::install_sqlserver_instance (
     sqlserver::common::set_tls_cert { "Set_TLS_certificate_for_${instance_name}":
       certificate_thumbprint => $certificate_thumbprint,
       instance_name => $instance_name,
-      require => Sslcertificate::Key_acl["${instance_name}_${svc_account}_certificate_read"],
+      require => [Sslcertificate::Key_acl["${instance_name}_${svc_account}_certificate_read"]],
     } 
   }
 }

--- a/manifests/common/install_sqlserver_instance.pp
+++ b/manifests/common/install_sqlserver_instance.pp
@@ -75,7 +75,9 @@ define sqlserver::common::install_sqlserver_instance (
       command => "\"${installer_path}\" ${quiet_params} ${parameters} /SkipRules=ServerCoreBlockUnsupportedSxSCheck",
       unless  => "reg.exe query ${get_instancename_from_registry}",
       require => Reboot["reboot before installing ${instance_name} (if pending)"],
-      before  => [Sslcertificate::Key_acl["${instance_name}_${svc_account}_certificate_read"]],
+      if ($certificate_thumbprint) {
+        before  => [Sslcertificate::Key_acl["${instance_name}_${svc_account}_certificate_read"]],
+      }
       returns => [0,3010],
     }
   }

--- a/manifests/common/install_sqlserver_instance.pp
+++ b/manifests/common/install_sqlserver_instance.pp
@@ -71,7 +71,9 @@ define sqlserver::common::install_sqlserver_instance (
   # If the instance isn't already in the list of installed instances, we probably need to install it, so let's do a reboot 
   # if there's one pending before doing the installation.
   if (!$facts['sqlserver_instances'][$instance_name]) {
-    sqlserver::common::reboot_resources { $instance_name:
+    reboot { "reboot before installing ${instance_name} (if pending)":
+      when  => pending,
+      apply => 'immediately',
       before => Exec["Install SQL Server instance: ${instance_name}"],
     }
   }

--- a/manifests/common/install_sqlserver_instance.pp
+++ b/manifests/common/install_sqlserver_instance.pp
@@ -66,6 +66,8 @@ define sqlserver::common::install_sqlserver_instance (
 
   $parameters = convert_to_parameter_string($params)
 
+  $svc_account = $params['sqlsvcaccount']
+
   if (!$facts['sqlserver_instances'][$instance_name]) {
     sqlserver::common::reboot_resources { $instance_name: }
   
@@ -79,7 +81,6 @@ define sqlserver::common::install_sqlserver_instance (
   }
 
   if ($certificate_thumbprint) {
-    $svc_account = $params['sqlsvcaccount']
 
     # Include instance name here to avoid duplicate declarations where more than one SQL instance exists on the same server
     sslcertificate::key_acl { "${instance_name}_${svc_account}_certificate_read":

--- a/manifests/common/patch_sqlserver_instance.pp
+++ b/manifests/common/patch_sqlserver_instance.pp
@@ -41,7 +41,7 @@ define sqlserver::common::patch_sqlserver_instance (
     # If we're going to do the patch, then trigger a reboot if one is pending before doing the actual install
     # If we're not going to do the patch, then don't trigger a reboot. This helps avoid doing reboots
     # when we don't need to (e.g. if a Windows Update requires a reboot).
-    reboot { "reboot before installing ${instance_name} Patch (if pending)":
+    reboot { "reboot before installing ${instance_name} version ${applies_to_version} Patch (if pending)":
       when  => pending,
       apply => 'immediately',
       before => Exec["${installer_path} : ${instance_name}"],
@@ -58,13 +58,13 @@ ${additional_parameters} \
     require => [
       Exec["Install SQL Server instance: ${instance_name}"],
     ],
-    notify => Reboot["Reboot after patching ${instance_name}"],
+    notify => Reboot["Reboot after patching ${instance_name} version ${applies_to_version}"],
     returns => [0,3010],
   }
 
-  reboot { "Reboot after patching ${instance_name}":
+  reboot { "Reboot after patching ${instance_name} version ${applies_to_version}":
     when    => 'refreshed',
     apply   => 'immediately',
-    message => "Reboot after patching ${instance_name}",
+    message => "Reboot after patching ${instance_name} version ${applies_to_version}",
   }
 }

--- a/manifests/v2005/instance.pp
+++ b/manifests/v2005/instance.pp
@@ -89,7 +89,6 @@ define sqlserver::v2005::instance (
         ],
       }
     }
-
   } else {
     warning('Cannot retrieve SQL instance data from the $sqlserver_instances fact. Skip patching this SQL Server instance in this run.')
   }


### PR DESCRIPTION
Description updated by @njhowell 

This PR is intended to prevent Puppet from automatically rebooting servers when we don't expect it to. 

Previously, our use of the `reboot` resource with `when => pending` meant that Puppet would trigger a reboot for any "reboot pending" condition, including when a Windows update requires a reboot. 

However, we only actually want Puppet to perform such a reboot, IF it's going to then install SQL Server, a SQL Server Patch or has just completed one of those installations. 

Puppet runs every 30 minutes by default, and we don't want it to trigger a reboot for Windows Updates when we may have a different system policy that allows installing updates during business hours, but not rebooting until outside of normal hours. 

The `reboot` resource does allow us to only reboot[ under certain conditions](https://forge.puppet.com/modules/puppetlabs/reboot/readme#reboot-when-certain-conditions-are-met) however that doesn't completely satisfy our requirement here -- it would, after all, be possible to be in a situation where there is a pending reboot for updates that needs to be completed before we install SQL Server (or a patch).