### PR TITLE
Update SSMS21 install for GA and fix tests

### DIFF
--- a/.kitchen.sqlservers.yml
+++ b/.kitchen.sqlservers.yml
@@ -2,6 +2,9 @@
 ---
 driver:
   name: vagrant
+  box_check_update: true
+  box_auto_update: true
+  box_auto_prune: true
 
 provisioner:
   name: puppet_apply
@@ -12,14 +15,15 @@ provisioner:
   require_chef_for_busser: false
   resolve_with_librarian_puppet: false
   puppet_detailed_exitcodes: true
+  require_puppet_repo: false
   require_puppet_collections: true
-  puppet_detailed_exitcodes: true
-  puppet_version: "6.28.0"
-  max_retries: 5
+  verify_host_key: false
+  max_retries: 3
   wait_for_retry: 40
   retry_on_exit_code:
     - 2 # The run succeeded, and some resources were changed.
     - 6 # The run succeeded, and included both changes and failures.
+
 
 transport:
   name: winrm
@@ -36,14 +40,13 @@ platforms:
       vm_hostname: sqlserver
     driver_config:
       box: red-gate/windows-2012r2
-      provision: true
-      vagrantfiles:
-        - spec/vagrantfile.rb
       customize:
         cpus: 2
         memory: 2048
         vrde: "off"
         vram: 64
+    provisioner:
+      puppet_version: "7.34.0"
   - name: windows-2019
     driver_plugin: vagrant
     driver:
@@ -55,46 +58,42 @@ platforms:
         memory: 2048
         vrde: "off"
         vram: 64
-      provision: true
-      vagrantfiles:
-        - spec/vagrantfile.rb
+    provisioner:
+      puppet_version: "7.34.0"
   - name: windows-2022
     driver_plugin: vagrant
     driver:
       vm_hostname: sqlserver
     driver_config:
       box: red-gate/windows-2022
-      provision: true
-      vagrantfiles:
-        - spec/vagrantfile.rb
       customize:
         cpus: 2
         memory: 2048
         vrde: "off"
         vram: 64
+    provisioner:
+      puppet_version: "7.34.0"
   - name: ubuntu-20.04
     driver_plugin: vagrant
-    driver:
-      vm_hostname: sqlserver
     driver_config:
       customize:
         audio: "none"
     driver:
       box: red-gate/ubuntu-2004
+      vm_hostname: sqlserver
     provisioner:
-      puppet_apt_collections_repo: https://apt.puppetlabs.com/puppet6-release-focal.deb
-      puppet_version: "6.28.0-1focal"
+      puppet_apt_collections_repo: https://apt.puppetlabs.com/puppet7-release-focal.deb
+      puppet_version: "7.34.0-1focal"
     transport:
       name: ssh_tgz
   - name: ubuntu-18.04
     driver_plugin: vagrant
-    driver:
-      vm_hostname: sqlserver
     driver_config:
       customize:
         audio: "none"
     driver:
       box: red-gate/ubuntu-1804
+      vm_hostname: sqlserver
     provisioner:
       puppet_apt_collections_repo: https://apt.puppetlabs.com/puppet6-release-bionic.deb
       puppet_version: "6.28.0-1bionic"

--- a/.kitchen.ssms.yml
+++ b/.kitchen.ssms.yml
@@ -2,6 +2,9 @@
 ---
 driver:
   name: vagrant
+  box_check_update: true
+  box_auto_update: true
+  box_auto_prune: true
 
 provisioner:
   name: puppet_apply
@@ -12,9 +15,9 @@ provisioner:
   require_chef_for_busser: false
   resolve_with_librarian_puppet: false
   puppet_detailed_exitcodes: true
+  require_puppet_repo: false
   require_puppet_collections: true
-  puppet_detailed_exitcodes: true
-  puppet_version: "6.28.0"
+  verify_host_key: false
   max_retries: 3
   wait_for_retry: 40
   retry_on_exit_code:
@@ -34,14 +37,16 @@ platforms:
     driver_plugin: vagrant
     driver_config:
       box: red-gate/windows-2019
-      customize:
-        cpus: 2
-        memory: 4096
-        vrde: "off"
-        vram: 64
-      provision: true
-      vagrantfiles:
-        - spec/vagrantfile.rb
+    provisioner:
+      puppet_version: "7.34.0"
+  - name: windows-2022
+    driver_plugin: vagrant
+    driver:
+      vm_hostname: sqlserver
+    driver_config:
+      box: red-gate/windows-2022
+    provisioner:
+      puppet_version: "7.34.0"
 
 suites:
   - name: localdbs

--- a/.kitchen.ssms.yml
+++ b/.kitchen.ssms.yml
@@ -74,3 +74,8 @@ suites:
       manifest: ssms20.pp
     verifier:
       command: rspec -c -f d -I spec spec/acceptance/ssms20_spec.rb
+  - name: ssms21
+    provisioner:
+      manifest: ssms21.pp
+    verifier:
+      command: rspec -c -f d -I spec spec/acceptance/ssms21_spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ gem 'rake', '~> 13'
 gem 'rake-performance'
 
 gem 'r10k', '~> 3'
+
+gem 'ffi', '~> 1.15.0'

--- a/manifests/ssms/v21.pp
+++ b/manifests/ssms/v21.pp
@@ -9,9 +9,9 @@
 # @param temp_folder
 #   path to temp folder
 class sqlserver::ssms::v21 (
-  String $source = 'https://aka.ms/ssms/21/preview/vs_SSMS.exe',
+  String $source = 'https://aka.ms/ssms/21/release/vs_SSMS.exe',
   String $filename = 'vs_SSMS.exe',
-  String $program_name = 'SQL Server Management Studio 21 Preview',
+  String $program_name = 'SQL Server Management Studio 21',
   String $temp_folder = 'C:/Windows/Temp',
 ) {
   include archive

--- a/spec/acceptance/ssms21_spec.rb
+++ b/spec/acceptance/ssms21_spec.rb
@@ -1,5 +1,5 @@
 require_relative 'spec_windowshelper'
 
-describe package('Microsoft SQL Server Management Studio - 21.*') do
+describe package('SQL Server Management Studio - 21*') do
   it { should be_installed}
 end

--- a/spec/acceptance/ssms21_spec.rb
+++ b/spec/acceptance/ssms21_spec.rb
@@ -1,0 +1,5 @@
+require_relative 'spec_windowshelper'
+
+describe package('Microsoft SQL Server Management Studio - 21.*') do
+  it { should be_installed}
+end

--- a/spec/acceptance/ssms21_spec.rb
+++ b/spec/acceptance/ssms21_spec.rb
@@ -1,5 +1,5 @@
 require_relative 'spec_windowshelper'
 
-describe package('SQL Server Management Studio - 21*') do
+describe package('SQL Server Management Studio 21*') do
   it { should be_installed}
 end

--- a/spec/manifests/ssms21.pp
+++ b/spec/manifests/ssms21.pp
@@ -1,0 +1,5 @@
+Reboot {
+  timeout => 10,
+}
+
+include sqlserver::ssms::v21

--- a/spec/manifests/ssms21.pp
+++ b/spec/manifests/ssms21.pp
@@ -1,5 +1,5 @@
 Reboot {
-  timeout => 10,
+  timeout => 120,
 }
 
 include sqlserver::ssms::v21


### PR DESCRIPTION
The updates the tests for this module to use Puppet7, and hopefully fixes the SSMS21 install. 