### PR TITLE
add ability to assign database role to a user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'kitchen-zip', :git => 'https://github.com/red-gate/kitchen-zip', :branch =>
 gem 'test-kitchen', '< 4.1.0' # pin to pre 4.1.0 until https://github.com/test-kitchen/test-kitchen/pull/2083 / https://github.com/test-kitchen/test-kitchen/issues/2082 is resolved
 
 gem 'kitchen-puppet'
-gem 'kitchen-vagrant', :git => 'https://github.com/njhowell/kitchen-vagrant', :branch => 'main'
+gem 'kitchen-vagrant', :git => 'https://github.com/njhowell/kitchen-vagrant', :branch => 'main' # temporary fork with an unmerged fix; switch back to the upstream gem once released
 
 # We use serverspec to test the state of our servers
 gem 'serverspec', '~> 2'

--- a/Gemfile
+++ b/Gemfile
@@ -1,24 +1,30 @@
 source 'https://rubygems.org'
 
-gem 'puppet-lint'
-gem 'puppet'
-
-gem 'test-kitchen', '< 3.8.0' # pin to pre 3.8.0 which introduced a change to how it uploads files which breaks ssh_tgz upload in the kitchen-zip module above
-gem 'kitchen-puppet', '>= 3.6.0'
-gem 'kitchen-vagrant'
+gem 'hiera-eyaml' # used to encrypt hiera data
 
 gem 'kitchen-zip', :git => 'https://github.com/red-gate/kitchen-zip', :branch => 'master'
+
+gem 'test-kitchen', '< 4.1.0' # pin to pre 4.1.0 until https://github.com/test-kitchen/test-kitchen/pull/2083 / https://github.com/test-kitchen/test-kitchen/issues/2082 is resolved
+
+gem 'kitchen-puppet'
+gem 'kitchen-vagrant', :git => 'https://github.com/njhowell/kitchen-vagrant', :branch => 'main'
 
 # We use serverspec to test the state of our servers
 gem 'serverspec', '~> 2'
 
-# We use rake as our build engine
+gem 'locale', '< 2.1.5' # pin to pre 2.1.5 which introduced a change that depends on fiddle, which fails to install
+
+gem 'winrm'
+
+gem 'puppet-lint'
+gem 'rubocop'
+gem 'yamllint'
+
+
 gem 'rake', '~> 13'
 # This gem tells us how long each rake task takes.
 gem 'rake-performance'
 
+gem 'ra10ke' # Add rake tasks to manage puppetfile
+
 gem 'r10k', '~> 3'
-
-gem 'ffi', '~> 1.15.0'
-gem 'rexml', '< 3.4.2'
-

--- a/manifests/users/db_role.pp
+++ b/manifests/users/db_role.pp
@@ -27,8 +27,8 @@ define sqlserver::users::db_role (
     server   => $server,
     username => $query_username,
     password => $query_password,
-    query    => "USE [${database_name}] CREATE USER ${login_name} FOR LOGIN ${login_name}",
-    unless   => "USE [${database_name}] IF(SELECT count(name) FROM sysusers where name = '${login_name}') != 1 raiserror('User is not created yet',1,1)",
+    query    => "USE [${database_name}] CREATE USER [${login_name}] FOR LOGIN [${login_name}]",
+    unless   => "USE [${database_name}] IF(SELECT count(name) FROM sys.database_principals where name = '${login_name}') != 1 raiserror('User is not created yet',1,1)",
   }
 
   sqlserver::sqlcmd::sqlquery { "${server} - Add role ${role_name} to ${login_name} login for database ${database_name}":
@@ -36,7 +36,7 @@ define sqlserver::users::db_role (
     username => $query_username,
     password => $query_password,
     query    => "USE [${database_name}] ALTER ROLE [${role_name}] ADD MEMBER [${login_name}]",
-    unless   => "IF(SELECT IS_ROLEMEMBER('${role_name}', '${login_name}')) != 1 raiserror ('Role is not assigned yet',1,1)",
+    unless   => "USE [${database_name}] IF(SELECT IS_ROLEMEMBER('${role_name}', '${login_name}')) != 1 raiserror ('Role is not assigned yet',1,1)",
     require  => Sqlserver::Sqlcmd::Sqlquery["${server} - Create user ${login_name} for login ${login_name} on database ${database_name}"],
   }
 }

--- a/manifests/users/db_role.pp
+++ b/manifests/users/db_role.pp
@@ -19,8 +19,8 @@ define sqlserver::users::db_role (
   String $login_name,
   String $role_name,
   String $database_name,
-  String[Optional]  $query_username = undef,
-  String[Optional] $query_password = undef
+  Optional[String]  $query_username = undef,
+  Optional[String] $query_password = undef
 ) {
 
   sqlserver::sqlcmd::sqlquery { "${server} - Create user ${login_name} for login ${login_name} on database ${database_name}":

--- a/manifests/users/db_role.pp
+++ b/manifests/users/db_role.pp
@@ -1,0 +1,42 @@
+# Assign a database role to a login
+# @summary Assigns a database role to a user
+#
+# @param server
+#  The SQL Server instance to connect to
+# @param login_name
+#  The login name to assign the role to
+# @param role_name
+#  The role name to assign to the login
+# @param database_name
+#  The database name where the role assignment will take place
+# @param query_username
+#  The username to use for the SQL query (optional)
+# @param query_password
+#  The password to use for the SQL query (optional)
+
+define sqlserver::users::db_role (
+  String $server,
+  String $login_name,
+  String $role_name,
+  String $database_name,
+  String[Optional]  $query_username = undef,
+  String[Optional] $query_password = undef
+) {
+
+  sqlserver::sqlcmd::sqlquery { "${server} - Create user ${login_name} for login ${login_name} on database ${database_name}":
+    server   => $server,
+    username => $query_username,
+    password => $query_password,
+    query    => "USE [${database_name}] CREATE USER ${login_name} FOR LOGIN ${login_name}",
+    unless   => "USE [${database_name}] IF(SELECT count(name) FROM sysusers where name = '${login_name}') != 1 raiserror('User is not created yet',1,1)",
+  }
+
+  sqlserver::sqlcmd::sqlquery { "${server} - Add role ${role_name} to ${login_name} login for database ${database_name}":
+    server   => $server,
+    username => $query_username,
+    password => $query_password,
+    query    => "USE [${database_name}] ALTER ROLE [${role_name}] ADD MEMBER [${login_name}]",
+    unless   => "IF(SELECT IS_ROLEMEMBER('${role_name}', '${login_name}')) != 1 raiserror ('Role is not assigned yet',1,1)",
+    require  => Sqlserver::Sqlcmd::Sqlquery["${server} - Create user ${login_name} for login ${login_name} on database ${database_name}"],
+  }
+}

--- a/spec/acceptance/sqlserver2022rtm_2_instances_spec.rb
+++ b/spec/acceptance/sqlserver2022rtm_2_instances_spec.rb
@@ -40,3 +40,7 @@ end
 describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL16.SQL2022_2\Mssqlserver\Supersocketnetlib\tcp\ipall') do
   it { should have_property_value('tcpport', :type_string, '1434') }
 end
+
+describe command('sqlcmd -S localhost\SQL2022_1 -Q "SET NOCOUNT ON; USE [tempdb]; SELECT CASE WHEN IS_ROLEMEMBER(\'db_datareader\', \'sql_user\') = 1 THEN \'ROLE_MEMBER_OK\' ELSE \'ROLE_MEMBER_MISSING\' END"') do
+  its(:stdout) { should include 'ROLE_MEMBER_OK' }
+end

--- a/spec/manifests/sqlserver2022ctp_2_instances.pp
+++ b/spec/manifests/sqlserver2022ctp_2_instances.pp
@@ -136,3 +136,9 @@ sqlserver::users::login_sql { 'SQL2022_1: sql_user login':
   login_name            => 'sql_user',
   default_database_name => 'tempdb',
 }
+-> sqlserver::users::db_role { 'SQL2022_1: sql_user is db_datareader on tempdb':
+  server        => 'localhost\SQL2022_1',
+  login_name    => 'sql_user',
+  role_name     => 'db_datareader',
+  database_name => 'tempdb',
+}


### PR DESCRIPTION
This adds a helper to allow us to more easily assign a database role to a given server login. 

If a user for the login doesn't exist on the database in question, then it gets created. 